### PR TITLE
Improve taxonomy fill-up and filter parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,11 +126,7 @@ dependencies = [
  "clap",
  "dirs",
  "flate2",
- "itertools",
- "regex",
  "reqwest",
- "serde",
- "serde_json",
  "tar",
 ]
 
@@ -260,12 +247,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -690,15 +671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,35 +911,6 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
-regex = "1"
 anyhow = "1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
+clap = { version = "4", features = ["derive"] }
+dirs = "4"
+flate2 = "1.0"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
 tar = "0.4"
-flate2 = "1.0"
-itertools = "0.10"
-dirs = "4"

--- a/src/cami.rs
+++ b/src/cami.rs
@@ -1,0 +1,147 @@
+use anyhow::{Context, Result};
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct Sample {
+    pub id: String,
+    pub version: Option<String>,
+    pub ranks: Vec<String>,
+    pub entries: Vec<Entry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Entry {
+    pub taxid: String,
+    pub rank: String,
+    pub taxpath: String,
+    pub taxpathsn: String,
+    pub percentage: f64,
+}
+
+impl Sample {
+    pub fn rank_index(&self, rank: &str) -> Option<usize> {
+        self.ranks.iter().position(|r| r == rank)
+    }
+}
+
+pub fn parse_cami(path: &Path) -> Result<Vec<Sample>> {
+    let file = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    let reader = BufReader::new(file);
+
+    let mut samples = Vec::new();
+    let mut current: Option<Sample> = None;
+
+    for line in reader.lines() {
+        let line = line?;
+        let line = line.trim_end();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with("@SampleID:") {
+            if let Some(s) = current.take() {
+                samples.push(s);
+            }
+            let id = line[10..].trim().to_string();
+            current = Some(Sample {
+                id,
+                version: None,
+                ranks: Vec::new(),
+                entries: Vec::new(),
+            });
+            continue;
+        }
+        if line.starts_with("@Version:") {
+            if let Some(s) = current.as_mut() {
+                s.version = Some(line[9..].trim().to_string());
+            }
+            continue;
+        }
+        if line.starts_with("@Ranks:") {
+            if let Some(s) = current.as_mut() {
+                let ranks = line[7..]
+                    .trim()
+                    .split('|')
+                    .map(|r| r.trim().to_string())
+                    .collect();
+                s.ranks = ranks;
+            }
+            continue;
+        }
+        if line.starts_with("@@TAXID") {
+            continue;
+        }
+
+        let fields: Vec<&str> = line.split('\t').collect();
+        let (taxid, rank, taxpath, taxpathsn, percentage) = if fields.len() >= 5 {
+            (fields[0], fields[1], fields[2], fields[3], fields[4])
+        } else {
+            let fields_ws: Vec<&str> = line.split_whitespace().collect();
+            if fields_ws.len() < 5 {
+                continue;
+            }
+            (
+                fields_ws[0],
+                fields_ws[1],
+                fields_ws[2],
+                fields_ws[3],
+                fields_ws[4],
+            )
+        };
+
+        if let Some(s) = current.as_mut() {
+            let entry = Entry {
+                taxid: taxid.to_string(),
+                rank: rank.to_string(),
+                taxpath: taxpath.to_string(),
+                taxpathsn: taxpathsn.to_string(),
+                percentage: percentage.parse().unwrap_or(0.0),
+            };
+            s.entries.push(entry);
+        }
+    }
+
+    if let Some(s) = current.take() {
+        samples.push(s);
+    }
+
+    Ok(samples)
+}
+
+pub fn load_samples(input: Option<&PathBuf>) -> Result<Vec<Sample>> {
+    let path = input
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from("examples/text.cami"));
+    parse_cami(&path)
+}
+
+pub fn write_cami(samples: &[Sample], out: &mut dyn Write) -> Result<()> {
+    for s in samples {
+        writeln!(out, "@SampleID:{}", s.id)?;
+        if let Some(v) = &s.version {
+            writeln!(out, "@Version:{}", v)?;
+        }
+        if !s.ranks.is_empty() {
+            writeln!(out, "@Ranks:{}", s.ranks.join("|"))?;
+        }
+        writeln!(out, "@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE")?;
+        for e in &s.entries {
+            writeln!(
+                out,
+                "{}\t{}\t{}\t{}\t{}",
+                e.taxid, e.rank, e.taxpath, e.taxpathsn, e.percentage
+            )?;
+        }
+    }
+    Ok(())
+}
+
+pub fn open_output(path: Option<&PathBuf>) -> Result<Box<dyn Write>> {
+    let writer: Box<dyn Write> = if let Some(p) = path {
+        Box::new(File::create(p)?)
+    } else {
+        Box::new(io::stdout())
+    };
+    Ok(writer)
+}

--- a/src/commands/fillup.rs
+++ b/src/commands/fillup.rs
@@ -1,0 +1,34 @@
+use crate::cami::{load_samples, open_output, write_cami};
+use crate::processing::{fill_up_default, fill_up_to};
+use crate::taxonomy::{Taxonomy, ensure_taxdump};
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+pub struct FillupConfig<'a> {
+    pub input: Option<&'a PathBuf>,
+    pub output: Option<&'a PathBuf>,
+    pub to_rank: Option<&'a str>,
+}
+
+pub fn run(cfg: &FillupConfig) -> Result<()> {
+    let mut samples = load_samples(cfg.input)?;
+    let dir = taxonomy_dir();
+    ensure_taxdump(&dir).with_context(|| format!("ensuring taxdump in {}", dir.display()))?;
+    let taxonomy = Taxonomy::load(&dir)?;
+
+    if let Some(rank) = cfg.to_rank {
+        fill_up_to(&mut samples, rank, &taxonomy);
+    } else {
+        fill_up_default(&mut samples, &taxonomy);
+    }
+
+    let mut out = open_output(cfg.output)?;
+    write_cami(&samples, &mut *out)?;
+    Ok(())
+}
+
+fn taxonomy_dir() -> PathBuf {
+    dirs::home_dir()
+        .map(|p| p.join(".cami"))
+        .unwrap_or_else(|| PathBuf::from(".cami"))
+}

--- a/src/commands/filter.rs
+++ b/src/commands/filter.rs
@@ -1,0 +1,51 @@
+use crate::cami::{load_samples, open_output, write_cami};
+use crate::expression::{apply_filter, expr_needs_taxdump, parse_expression};
+use crate::processing::{fill_up_to, renormalize};
+use crate::taxonomy::{Taxonomy, ensure_taxdump};
+use anyhow::{Context, Result, anyhow};
+use std::path::PathBuf;
+
+pub struct FilterConfig<'a> {
+    pub expression: &'a str,
+    pub output: Option<&'a PathBuf>,
+    pub fill_up: bool,
+    pub to_rank: &'a str,
+    pub renorm: bool,
+    pub input: Option<&'a PathBuf>,
+}
+
+pub fn run(cfg: &FilterConfig) -> Result<()> {
+    let samples = load_samples(cfg.input)?;
+    let expr = parse_expression(cfg.expression).context("parsing expression")?;
+    let needs_taxdump = expr_needs_taxdump(&expr) || cfg.fill_up;
+
+    let taxonomy = if needs_taxdump {
+        let dir = taxonomy_dir();
+        ensure_taxdump(&dir).with_context(|| format!("ensuring taxdump in {}", dir.display()))?;
+        Some(Taxonomy::load(&dir)?)
+    } else {
+        None
+    };
+
+    let mut filtered = apply_filter(&samples, &expr, taxonomy.as_ref());
+
+    if cfg.fill_up {
+        let tax = taxonomy
+            .as_ref()
+            .ok_or_else(|| anyhow!("fill-up requires taxonomy data"))?;
+        fill_up_to(&mut filtered, cfg.to_rank, tax);
+    }
+    if cfg.renorm {
+        renormalize(&mut filtered);
+    }
+
+    let mut out = open_output(cfg.output)?;
+    write_cami(&filtered, &mut *out)?;
+    Ok(())
+}
+
+fn taxonomy_dir() -> PathBuf {
+    dirs::home_dir()
+        .map(|p| p.join(".cami"))
+        .unwrap_or_else(|| PathBuf::from(".cami"))
+}

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,0 +1,36 @@
+use crate::cami::load_samples;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+pub struct ListConfig<'a> {
+    pub input: Option<&'a PathBuf>,
+}
+
+pub fn run(cfg: &ListConfig) -> Result<()> {
+    let samples = load_samples(cfg.input)?;
+    let mut out = io::stdout();
+
+    for sample in &samples {
+        writeln!(out, "Sample: {}", sample.id)?;
+        writeln!(out, "  Ranks: {}", sample.ranks.join(", "))?;
+        writeln!(out, "  Total taxa: {}", sample.entries.len())?;
+
+        let mut stats: HashMap<&str, (usize, f64)> = HashMap::new();
+        for entry in &sample.entries {
+            let stat = stats.entry(&entry.rank).or_insert((0, 0.0));
+            if entry.percentage > 0.0 {
+                stat.0 += 1;
+                stat.1 += entry.percentage;
+            }
+        }
+
+        for rank in &sample.ranks {
+            let (count, total) = stats.get(rank.as_str()).cloned().unwrap_or((0, 0.0));
+            writeln!(out, "    {}: taxa={} total={:.3}", rank, count, total)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,5 @@
+pub mod fillup;
+pub mod filter;
+pub mod list;
+pub mod preview;
+pub mod renorm;

--- a/src/commands/preview.rs
+++ b/src/commands/preview.rs
@@ -1,0 +1,32 @@
+use crate::cami::load_samples;
+use anyhow::Result;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+pub struct PreviewConfig<'a> {
+    pub n: usize,
+    pub input: Option<&'a PathBuf>,
+}
+
+pub fn run(cfg: &PreviewConfig) -> Result<()> {
+    let samples = load_samples(cfg.input)?;
+    let mut out = io::stdout();
+    for sample in &samples {
+        writeln!(out, "@SampleID:{}", sample.id)?;
+        if let Some(version) = &sample.version {
+            writeln!(out, "@Version:{}", version)?;
+        }
+        if !sample.ranks.is_empty() {
+            writeln!(out, "@Ranks:{}", sample.ranks.join("|"))?;
+        }
+        writeln!(out, "@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE")?;
+        for entry in sample.entries.iter().take(cfg.n) {
+            writeln!(
+                out,
+                "{}\t{}\t{}\t{}\t{}",
+                entry.taxid, entry.rank, entry.taxpath, entry.taxpathsn, entry.percentage
+            )?;
+        }
+    }
+    Ok(())
+}

--- a/src/commands/renorm.rs
+++ b/src/commands/renorm.rs
@@ -1,0 +1,17 @@
+use crate::cami::{load_samples, open_output, write_cami};
+use crate::processing::renormalize;
+use anyhow::Result;
+use std::path::PathBuf;
+
+pub struct RenormConfig<'a> {
+    pub input: Option<&'a PathBuf>,
+    pub output: Option<&'a PathBuf>,
+}
+
+pub fn run(cfg: &RenormConfig) -> Result<()> {
+    let mut samples = load_samples(cfg.input)?;
+    renormalize(&mut samples);
+    let mut out = open_output(cfg.output)?;
+    write_cami(&samples, &mut *out)?;
+    Ok(())
+}

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,0 +1,519 @@
+use crate::cami::{Entry, Sample};
+use crate::taxonomy::{Taxonomy, parse_taxid};
+use anyhow::{Result, anyhow};
+
+#[derive(Debug, Clone)]
+pub enum Expr {
+    And(Box<Expr>, Box<Expr>),
+    Or(Box<Expr>, Box<Expr>),
+    Atom(String),
+}
+
+pub fn parse_expression(s: &str) -> Result<Expr> {
+    let normalized = s.replace("&&", "&").replace("||", "|");
+    let chars: Vec<char> = normalized.chars().collect();
+    let mut pos = 0;
+
+    fn skip_ws(chars: &[char], pos: &mut usize) {
+        while *pos < chars.len() && chars[*pos].is_whitespace() {
+            *pos += 1;
+        }
+    }
+
+    fn parse_primary(chars: &[char], pos: &mut usize) -> Result<Expr> {
+        skip_ws(chars, pos);
+        if *pos >= chars.len() {
+            return Err(anyhow!("unexpected end of expression"));
+        }
+        if chars[*pos] == '(' {
+            *pos += 1;
+            let expr = parse_expr(chars, pos)?;
+            skip_ws(chars, pos);
+            if *pos >= chars.len() || chars[*pos] != ')' {
+                return Err(anyhow!("missing closing parenthesis"));
+            }
+            *pos += 1;
+            Ok(expr)
+        } else {
+            let start = *pos;
+            while *pos < chars.len()
+                && chars[*pos] != '&'
+                && chars[*pos] != '|'
+                && chars[*pos] != ')'
+            {
+                *pos += 1;
+            }
+            let atom: String = chars[start..*pos].iter().collect();
+            Ok(Expr::Atom(atom.trim().to_string()))
+        }
+    }
+
+    fn parse_term(chars: &[char], pos: &mut usize) -> Result<Expr> {
+        let mut left = parse_primary(chars, pos)?;
+        loop {
+            skip_ws(chars, pos);
+            if *pos + 1 < chars.len() && chars[*pos] == '&' && chars[*pos + 1] == '&' {
+                *pos += 1;
+            }
+            if *pos >= chars.len() || chars[*pos] != '&' {
+                break;
+            }
+            *pos += 1;
+            let right = parse_primary(chars, pos)?;
+            left = Expr::And(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_expr(chars: &[char], pos: &mut usize) -> Result<Expr> {
+        let mut left = parse_term(chars, pos)?;
+        loop {
+            skip_ws(chars, pos);
+            if *pos + 1 < chars.len() && chars[*pos] == '|' && chars[*pos + 1] == '|' {
+                *pos += 1;
+            }
+            if *pos >= chars.len() || chars[*pos] != '|' {
+                break;
+            }
+            *pos += 1;
+            let right = parse_term(chars, pos)?;
+            left = Expr::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    let expr = parse_expr(&chars, &mut pos)?;
+    skip_ws(&chars, &mut pos);
+    if pos != chars.len() {
+        return Err(anyhow!("unexpected characters after expression"));
+    }
+    Ok(expr)
+}
+
+pub fn expr_needs_taxdump(expr: &Expr) -> bool {
+    match expr {
+        Expr::And(a, b) | Expr::Or(a, b) => expr_needs_taxdump(a) || expr_needs_taxdump(b),
+        Expr::Atom(s) => {
+            let trimmed = s.trim().trim_start_matches('!').trim_start();
+            trimmed.starts_with("tax") || trimmed.starts_with('t')
+        }
+    }
+}
+
+pub fn apply_filter(samples: &[Sample], expr: &Expr, taxonomy: Option<&Taxonomy>) -> Vec<Sample> {
+    let mut filtered = Vec::new();
+    for (sample_index, sample) in samples.iter().enumerate() {
+        let mut ns = sample.clone();
+        ns.entries = ns
+            .entries
+            .iter()
+            .cloned()
+            .filter(|entry| eval_expr(expr, samples, sample, entry, sample_index, taxonomy))
+            .collect();
+        if !ns.entries.is_empty() {
+            filtered.push(ns);
+        }
+    }
+    filtered
+}
+
+fn eval_expr(
+    e: &Expr,
+    samples: &[Sample],
+    sample: &Sample,
+    entry: &Entry,
+    sample_index: usize,
+    taxonomy: Option<&Taxonomy>,
+) -> bool {
+    match e {
+        Expr::And(a, b) => {
+            eval_expr(a, samples, sample, entry, sample_index, taxonomy)
+                && eval_expr(b, samples, sample, entry, sample_index, taxonomy)
+        }
+        Expr::Or(a, b) => {
+            eval_expr(a, samples, sample, entry, sample_index, taxonomy)
+                || eval_expr(b, samples, sample, entry, sample_index, taxonomy)
+        }
+        Expr::Atom(s) => eval_atom(s, samples, sample, entry, sample_index, taxonomy),
+    }
+}
+
+fn eval_atom(
+    atom: &str,
+    samples: &[Sample],
+    sample: &Sample,
+    entry: &Entry,
+    sample_index: usize,
+    taxonomy: Option<&Taxonomy>,
+) -> bool {
+    let atom = atom.trim();
+
+    if let Some(res) = eval_rank(atom, sample, entry) {
+        return res;
+    }
+    if let Some(res) = eval_sample(atom, samples, sample, sample_index) {
+        return res;
+    }
+    if let Some(res) = eval_abundance(atom, entry) {
+        return res;
+    }
+    if let Some(res) = eval_tax(atom, entry, taxonomy) {
+        return res;
+    }
+
+    false
+}
+
+fn eval_rank(atom: &str, sample: &Sample, entry: &Entry) -> Option<bool> {
+    let rest = if let Some(r) = atom.strip_prefix("rank") {
+        r
+    } else if let Some(r) = atom.strip_prefix('r') {
+        r
+    } else {
+        return None;
+    };
+    let rest = rest.trim_start();
+    if let Some(v) = rest.strip_prefix("==") {
+        let values: Vec<&str> = v
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if values.is_empty() {
+            return Some(entry.rank == v.trim());
+        }
+        return Some(values.iter().any(|value| entry.rank == *value));
+    }
+    if let Some(v) = rest.strip_prefix("<=") {
+        return Some(rank_compare(sample, &entry.rank, v.trim(), |a, b| a >= b));
+    }
+    if let Some(v) = rest.strip_prefix("<") {
+        return Some(rank_compare(sample, &entry.rank, v.trim(), |a, b| a > b));
+    }
+    if let Some(v) = rest.strip_prefix(">=") {
+        return Some(rank_compare(sample, &entry.rank, v.trim(), |a, b| a <= b));
+    }
+    if let Some(v) = rest.strip_prefix('>') {
+        return Some(rank_compare(sample, &entry.rank, v.trim(), |a, b| a < b));
+    }
+    None
+}
+
+fn rank_compare<F>(sample: &Sample, entry_rank: &str, other: &str, cmp: F) -> bool
+where
+    F: Fn(usize, usize) -> bool,
+{
+    let Some(entry_idx) = sample.rank_index(entry_rank) else {
+        return false;
+    };
+    let Some(other_idx) = sample.rank_index(other) else {
+        return false;
+    };
+    cmp(entry_idx, other_idx)
+}
+
+fn eval_sample(
+    atom: &str,
+    samples: &[Sample],
+    sample: &Sample,
+    sample_index: usize,
+) -> Option<bool> {
+    let rest = if let Some(r) = atom.strip_prefix("sample") {
+        r
+    } else if let Some(r) = atom.strip_prefix('s') {
+        r
+    } else {
+        return None;
+    };
+    let rest = rest.trim_start();
+    if let Some(v) = rest.strip_prefix("==") {
+        return Some(match_sample(v.trim(), samples, sample, sample_index));
+    }
+    None
+}
+
+fn match_sample(selector: &str, samples: &[Sample], sample: &Sample, sample_index: usize) -> bool {
+    if selector.is_empty() || selector == ":" {
+        return true;
+    }
+    let mut matched = false;
+    for part in split_unquoted(selector, ',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        if part == ":" || part == "." {
+            matched = true;
+            break;
+        }
+        let colon_parts = split_unquoted(part, ':');
+        if colon_parts.len() == 2 {
+            if match_sample_range_parts(&colon_parts[0], &colon_parts[1], samples, sample_index) {
+                matched = true;
+                break;
+            }
+        } else if colon_parts.len() == 1 {
+            if match_sample_value(&colon_parts[0], samples, sample, sample_index) {
+                matched = true;
+                break;
+            }
+        } else if match_sample_value(part, samples, sample, sample_index) {
+            matched = true;
+            break;
+        }
+    }
+    matched
+}
+
+fn match_sample_value(
+    value: &str,
+    samples: &[Sample],
+    sample: &Sample,
+    sample_index: usize,
+) -> bool {
+    let Some((parsed, quoted)) = parse_selector_value(value) else {
+        return true;
+    };
+    if !quoted {
+        if let Ok(idx) = parsed.parse::<usize>() {
+            return idx == sample_index + 1;
+        }
+    }
+    if let Some(idx) = samples.iter().position(|s| s.id == parsed) {
+        return idx == sample_index;
+    }
+    parsed == sample.id
+}
+
+fn match_sample_range_parts(
+    start_raw: &str,
+    end_raw: &str,
+    samples: &[Sample],
+    sample_index: usize,
+) -> bool {
+    let start_val = parse_selector_value(start_raw);
+    let end_val = parse_selector_value(end_raw);
+
+    if start_val.is_none() && end_val.is_none() {
+        return true;
+    }
+
+    let start_idx = match start_val {
+        Some(ref value) => selector_value_to_index(value, samples),
+        None => Some(0),
+    };
+    if start_val.is_some() && start_idx.is_none() {
+        return false;
+    }
+
+    let end_idx = match end_val {
+        Some(ref value) => selector_value_to_index(value, samples),
+        None => samples.len().checked_sub(1),
+    };
+    if end_val.is_some() && end_idx.is_none() {
+        return false;
+    }
+
+    let (Some(start), Some(end)) = (start_idx, end_idx) else {
+        return false;
+    };
+
+    let (low, high) = if start <= end {
+        (start, end)
+    } else {
+        (end, start)
+    };
+    (low..=high).contains(&sample_index)
+}
+
+fn eval_abundance(atom: &str, entry: &Entry) -> Option<bool> {
+    let rest = if let Some(r) = atom.strip_prefix("abundance") {
+        r
+    } else if let Some(r) = atom.strip_prefix('a') {
+        r
+    } else {
+        return None;
+    };
+    let rest = rest.trim_start();
+    if let Some(v) = rest.strip_prefix("<=") {
+        return Some(entry.percentage <= parse_f64(v.trim()));
+    }
+    if let Some(v) = rest.strip_prefix(">=") {
+        return Some(entry.percentage >= parse_f64(v.trim()));
+    }
+    if let Some(v) = rest.strip_prefix("==") {
+        let target = parse_f64(v.trim());
+        return Some((entry.percentage - target).abs() < 1e-9);
+    }
+    if let Some(v) = rest.strip_prefix('>') {
+        return Some(entry.percentage > parse_f64(v.trim()));
+    }
+    if let Some(v) = rest.strip_prefix('<') {
+        return Some(entry.percentage < parse_f64(v.trim()));
+    }
+    None
+}
+
+fn split_unquoted(input: &str, delimiter: char) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut quote_char = '\0';
+    for ch in input.chars() {
+        match ch {
+            '"' | '\'' => {
+                if in_quotes {
+                    if ch == quote_char {
+                        in_quotes = false;
+                    }
+                } else {
+                    in_quotes = true;
+                    quote_char = ch;
+                }
+                current.push(ch);
+            }
+            _ if ch == delimiter && !in_quotes => {
+                parts.push(current.trim().to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        parts.push(current.trim().to_string());
+    } else if input.ends_with(delimiter) {
+        parts.push(String::new());
+    }
+    if parts.is_empty() {
+        parts.push(String::new());
+    }
+    parts
+}
+
+fn parse_selector_value(raw: &str) -> Option<(String, bool)> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "." {
+        return None;
+    }
+    let first = trimmed.chars().next();
+    let last = trimmed.chars().last();
+    if trimmed.len() >= 2 {
+        if let (Some(f), Some(l)) = (first, last) {
+            if (f == '"' && l == '"') || (f == '\'' && l == '\'') {
+                return Some((trimmed[1..trimmed.len() - 1].to_string(), true));
+            }
+        }
+    }
+    Some((trimmed.to_string(), false))
+}
+
+fn selector_value_to_index(value: &(String, bool), samples: &[Sample]) -> Option<usize> {
+    if !value.1 {
+        if let Ok(idx) = value.0.parse::<usize>() {
+            return Some(idx.saturating_sub(1));
+        }
+    }
+    samples.iter().position(|s| s.id == value.0)
+}
+
+fn parse_f64(s: &str) -> f64 {
+    s.parse().unwrap_or(0.0)
+}
+
+fn eval_tax(atom: &str, entry: &Entry, taxonomy: Option<&Taxonomy>) -> Option<bool> {
+    let mut working = atom.trim();
+    let mut negate = false;
+    if let Some(rest) = working.strip_prefix('!') {
+        negate = true;
+        working = rest.trim_start();
+    }
+
+    let rest = if let Some(r) = working.strip_prefix("tax") {
+        r
+    } else if let Some(r) = working.strip_prefix('t') {
+        r
+    } else {
+        return None;
+    };
+
+    let rest = rest.trim_start();
+    let (op, value) = if let Some(v) = rest.strip_prefix("==") {
+        ("==", v.trim())
+    } else if let Some(v) = rest.strip_prefix("<=") {
+        ("<=", v.trim())
+    } else if let Some(v) = rest.strip_prefix('<') {
+        ("<", v.trim())
+    } else {
+        return Some(false);
+    };
+
+    let result = if let Some(taxonomy) = taxonomy {
+        eval_taxonomy(entry, taxonomy, op, value)
+    } else {
+        eval_taxpath(entry, op, value)
+    };
+    Some(if negate { !result } else { result })
+}
+
+fn eval_taxonomy(entry: &Entry, taxonomy: &Taxonomy, op: &str, value: &str) -> bool {
+    let entry_taxid = parse_taxid(&entry.taxid);
+    let target_taxid = parse_taxid(value);
+
+    match op {
+        "==" => match (entry_taxid, target_taxid) {
+            (Some(e), Some(t)) => e == t,
+            _ => entry.taxid == value,
+        },
+        "<=" => {
+            if let (Some(e), Some(t)) = (entry_taxid, target_taxid) {
+                if e == t {
+                    return true;
+                }
+                taxonomy
+                    .ancestors_of(e)
+                    .iter()
+                    .any(|ancestor| *ancestor == t)
+            } else {
+                entry.taxpath.split('|').any(|tid| tid == value)
+            }
+        }
+        "<" => {
+            if let (Some(e), Some(t)) = (entry_taxid, target_taxid) {
+                if e == t {
+                    return false;
+                }
+                taxonomy
+                    .ancestors_of(e)
+                    .iter()
+                    .any(|ancestor| *ancestor == t)
+            } else {
+                entry
+                    .taxpath
+                    .split('|')
+                    .any(|tid| tid == value && tid != entry.taxid)
+            }
+        }
+        _ => false,
+    }
+}
+
+fn eval_taxpath(entry: &Entry, op: &str, value: &str) -> bool {
+    match op {
+        "==" => entry
+            .taxpath
+            .split('|')
+            .last()
+            .map(|tid| tid == value)
+            .unwrap_or(false),
+        "<=" => entry.taxpath.split('|').any(|tid| tid == value),
+        "<" => {
+            let mut parts: Vec<&str> = entry.taxpath.split('|').collect();
+            if let Some(last) = parts.pop() {
+                parts.contains(&value) && last != value
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,20 @@
-use anyhow::{Context, Result};
+mod cami;
+mod commands;
+mod expression;
+mod processing;
+mod taxonomy;
+
+use anyhow::Result;
 use clap::{Parser, Subcommand};
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::{self, BufRead, BufReader, Write};
 use std::path::PathBuf;
-// std::io::Write not directly needed in this scope
-use reqwest::blocking::get;
-use std::fs;
-use flate2::read::GzDecoder;
-use tar::Archive;
+
+use commands::{
+    fillup::{self as fillup_cmd, FillupConfig},
+    filter::{self as filter_cmd, FilterConfig},
+    list::{self as list_cmd, ListConfig},
+    preview::{self as preview_cmd, PreviewConfig},
+    renorm::{self as renorm_cmd, RenormConfig},
+};
 
 #[derive(Parser)]
 #[command(author, version, about)]
@@ -21,7 +27,7 @@ struct Cli {
 enum Commands {
     /// Filter CAMI profiling data
     Filter {
-        /// Filter expression, e.g. "rank==species & abundance>=0.1"
+        /// Filter expression, e.g. "r==species & a>=0.1"
         expression: String,
         /// Output file (defaults to stdout)
         #[arg(short, long)]
@@ -29,19 +35,19 @@ enum Commands {
         /// Fill up missing higher ranks using NCBI taxdump (downloads to ~/.cami)
         #[arg(long)]
         fill_up: bool,
-        /// Target rank to fill up to (inclusive), e.g. phylum
+        /// Target rank to fill up to (inclusive)
         #[arg(long, default_value = "phylum")]
         to_rank: String,
         /// Renormalize percentages to 100 per rank after filtering/filling
         #[arg(long)]
         renorm: bool,
-        /// Input CAMI file (positional, optional). If omitted, defaults to examples/text.cami
+        /// Input CAMI file
         #[arg(value_name = "INPUT", index = 2)]
         input: Option<PathBuf>,
     },
-    /// List samples and summary statistics
+    /// List samples and per-rank summaries
     List {
-        /// Input CAMI file (positional, optional). If omitted, defaults to examples/text.cami
+        /// Input CAMI file
         #[arg(value_name = "INPUT", index = 1)]
         input: Option<PathBuf>,
     },
@@ -50,589 +56,85 @@ enum Commands {
         /// Number of entries per sample to show
         #[arg(short = 'n', long, default_value_t = 5)]
         n: usize,
-        /// Input CAMI file (positional, optional). If omitted, defaults to examples/text.cami
+        /// Input CAMI file
         #[arg(value_name = "INPUT", index = 1)]
         input: Option<PathBuf>,
     },
-}
-
-#[derive(Debug, Clone)]
-struct Sample {
-    id: String,
-    version: Option<String>,
-    ranks: Vec<String>,
-    entries: Vec<Entry>,
-}
-
-#[derive(Debug, Clone)]
-struct Entry {
-    taxid: String,
-    rank: String,
-    taxpath: String,
-    taxpathsn: String,
-    percentage: f64,
-}
-
-fn parse_cami(path: &PathBuf) -> Result<Vec<Sample>> {
-    let file = File::open(path).with_context(|| format!("opening {}", path.display()))?;
-    let reader = BufReader::new(file);
-
-    let mut samples = Vec::new();
-    let mut current: Option<Sample> = None;
-
-
-    for line in reader.lines() {
-        let line = line?;
-        let line = line.trim_end();
-        if line.is_empty() {
-            continue;
-        }
-        if line.starts_with('#') {
-            continue;
-        }
-        if line.starts_with("@SampleID:") {
-            if let Some(s) = current.take() {
-                samples.push(s);
-            }
-            let id = line[10..].trim().to_string();
-            current = Some(Sample {
-                id,
-                version: None,
-                ranks: Vec::new(),
-                entries: Vec::new(),
-            });
-            continue;
-        }
-        if line.starts_with("@Version:") {
-            if let Some(s) = current.as_mut() {
-                s.version = Some(line[9..].trim().to_string());
-            }
-            continue;
-        }
-        if line.starts_with("@Ranks:") {
-            if let Some(s) = current.as_mut() {
-                let ranks = line[7..].trim().split('|').map(|s| s.to_string()).collect();
-                s.ranks = ranks;
-            }
-            continue;
-        }
-        if line.starts_with("@@TAXID") {
-            // header for table, skip
-            continue;
-        }
-
-        // Data row: TAXID<TAB>RANK<TAB>TAXPATH<TAB>TAXPATHSN<TAB>PERCENTAGE
-        let fields: Vec<&str> = line.split('\t').collect();
-        if fields.len() < 5 {
-            // some files may use multiple spaces; try splitting on whitespace
-            let fields_ws: Vec<&str> = line.split_whitespace().collect();
-            if fields_ws.len() < 5 {
-                continue;
-            }
-            if let Some(s) = current.as_mut() {
-                let entry = Entry {
-                    taxid: fields_ws[0].to_string(),
-                    rank: fields_ws[1].to_string(),
-                    taxpath: fields_ws[2].to_string(),
-                    taxpathsn: fields_ws[3].to_string(),
-                    percentage: fields_ws[4].parse().unwrap_or(0.0),
-                };
-                s.entries.push(entry);
-            }
-            continue;
-        }
-
-        if let Some(s) = current.as_mut() {
-            let entry = Entry {
-                taxid: fields[0].to_string(),
-                rank: fields[1].to_string(),
-                taxpath: fields[2].to_string(),
-                taxpathsn: fields[3].to_string(),
-                percentage: fields[4].parse().unwrap_or(0.0),
-            };
-            s.entries.push(entry);
-        }
-    }
-
-    if let Some(s) = current.take() {
-        samples.push(s);
-    }
-
-    Ok(samples)
-}
-
-#[derive(Debug)]
-enum Expr {
-    And(Box<Expr>, Box<Expr>),
-    Or(Box<Expr>, Box<Expr>),
-    Atom(String),
-}
-
-// Tokenize expression into atoms, parentheses and operators & and |
-fn parse_expression(s: &str) -> Result<Expr> {
-    let s = s.replace("&&", "&").replace("||", "|");
-    let chars: Vec<char> = s.chars().collect();
-
-    let mut pos = 0;
-
-    fn skip_ws(chars: &Vec<char>, pos: &mut usize) {
-        while *pos < chars.len() && chars[*pos].is_whitespace() { *pos += 1; }
-    }
-
-    fn parse_primary(chars: &Vec<char>, pos: &mut usize) -> Result<Expr> {
-        skip_ws(chars, pos);
-        if *pos >= chars.len() { return Err(anyhow::anyhow!("unexpected end")); }
-        if chars[*pos] == '(' {
-            *pos += 1;
-            let e = parse_or(chars, pos)?;
-            skip_ws(chars, pos);
-            if *pos < chars.len() && chars[*pos] == ')' { *pos += 1; Ok(e) } else { Err(anyhow::anyhow!("missing )")) }
-        } else {
-            // read until whitespace or & or |
-            let start = *pos;
-            while *pos < chars.len() && !chars[*pos].is_whitespace() && chars[*pos] != '&' && chars[*pos] != '|' && chars[*pos] != ')' {
-                *pos += 1;
-            }
-            let atom: String = chars[start..*pos].iter().collect::<String>().trim().to_string();
-            Ok(Expr::Atom(atom))
-        }
-    }
-
-    fn parse_and(chars: &Vec<char>, pos: &mut usize) -> Result<Expr> {
-        let mut left = parse_primary(chars, pos)?;
-        skip_ws(chars, pos);
-        while *pos < chars.len() && chars[*pos] == '&' {
-            *pos += 1;
-            let right = parse_primary(chars, pos)?;
-            left = Expr::And(Box::new(left), Box::new(right));
-            skip_ws(chars, pos);
-        }
-        Ok(left)
-    }
-
-    fn parse_or(chars: &Vec<char>, pos: &mut usize) -> Result<Expr> {
-        let mut left = parse_and(chars, pos)?;
-        skip_ws(chars, pos);
-        while *pos < chars.len() && chars[*pos] == '|' {
-            *pos += 1;
-            let right = parse_and(chars, pos)?;
-            left = Expr::Or(Box::new(left), Box::new(right));
-            skip_ws(chars, pos);
-        }
-        Ok(left)
-    }
-
-    let e = parse_or(&chars, &mut pos)?;
-    Ok(e)
-}
-
-fn eval_expr(e: &Expr, samples: &Vec<Sample>, sample: &Sample, entry: &Entry, sample_index: usize, nodes: Option<&HashMap<String,(String,String)>>, names: Option<&HashMap<String,String>>, ancestors: Option<&HashMap<String,std::collections::HashSet<String>>>) -> bool {
-    match e {
-        Expr::And(a, b) => eval_expr(a, samples, sample, entry, sample_index, nodes, names, ancestors) && eval_expr(b, samples, sample, entry, sample_index, nodes, names, ancestors),
-        Expr::Or(a, b) => eval_expr(a, samples, sample, entry, sample_index, nodes, names, ancestors) || eval_expr(b, samples, sample, entry, sample_index, nodes, names, ancestors),
-        Expr::Atom(s) => eval_atom(s, samples, sample, entry, sample_index, nodes, names, ancestors),
-    }
-}
-
-fn eval_atom(s: &str, _samples: &Vec<Sample>, sample: &Sample, entry: &Entry, sample_index: usize, nodes: Option<&HashMap<String,(String,String)>>, _names: Option<&HashMap<String,String>>, ancestors: Option<&HashMap<String,std::collections::HashSet<String>>>) -> bool {
-    let s = s.trim();
-    if s.starts_with("rank==") {
-        let v = s[6..].trim();
-        return entry.rank == v;
-    }
-    if s.starts_with("rank<=") {
-        let v = s[6..].trim();
-        if let Some(pos_v) = sample.ranks.iter().position(|r| r == v) {
-            if let Some(pos_e) = sample.ranks.iter().position(|r| r == &entry.rank) {
-                return pos_e >= pos_v;
-            }
-        }
-        return false;
-    }
-    if s.starts_with("rank<") {
-        let v = s[5..].trim();
-        if let Some(pos_v) = sample.ranks.iter().position(|r| r == v) {
-            if let Some(pos_e) = sample.ranks.iter().position(|r| r == &entry.rank) {
-                return pos_e > pos_v;
-            }
-        }
-        return false;
-    }
-    if s.starts_with("rank>=") {
-        let v = s[7..].trim();
-        if let Some(pos_v) = sample.ranks.iter().position(|r| r == v) {
-            if let Some(pos_e) = sample.ranks.iter().position(|r| r == &entry.rank) {
-                return pos_e <= pos_v;
-            }
-        }
-        return false;
-    }
-    if s.starts_with("rank>") {
-        let v = s[5..].trim();
-        if let Some(pos_v) = sample.ranks.iter().position(|r| r == v) {
-            if let Some(pos_e) = sample.ranks.iter().position(|r| r == &entry.rank) {
-                return pos_e < pos_v;
-            }
-        }
-        return false;
-    }
-
-    if s.starts_with("sample==") {
-        let v = s[8..].trim();
-        if v.contains(':') {
-            let parts: Vec<&str> = v.split(':').collect();
-            let a: usize = parts[0].parse().unwrap_or(1);
-            let b: usize = parts[1].parse().unwrap_or(a);
-            return (a..=b).contains(&(sample_index + 1));
-        }
-        if v.contains(',') {
-            let vals: Vec<&str> = v.split(',').map(|p| p.trim()).collect();
-            return vals.iter().any(|val| *val == sample.id || *val == (sample_index+1).to_string());
-        }
-        return v == sample.id || v == (sample_index+1).to_string();
-    }
-
-    if s.starts_with("abundance") {
-        if let Some(idx) = s.find("<=") {
-            let val: f64 = s[idx+2..].trim().parse().unwrap_or(0.0);
-            return entry.percentage <= val;
-        }
-        if let Some(idx) = s.find(">=") {
-            let val: f64 = s[idx+2..].trim().parse().unwrap_or(0.0);
-            return entry.percentage >= val;
-        }
-        if let Some(idx) = s.find("==") {
-            let val: f64 = s[idx+2..].trim().parse().unwrap_or(0.0);
-            return (entry.percentage - val).abs() < 1e-9;
-        }
-        if let Some(idx) = s.find('>') {
-            let val: f64 = s[idx+1..].trim().parse().unwrap_or(0.0);
-            return entry.percentage > val;
-        }
-        if let Some(idx) = s.find('<') {
-            let val: f64 = s[idx+1..].trim().parse().unwrap_or(0.0);
-            return entry.percentage < val;
-        }
-    }
-
-    // tax operations: tax==, tax<=, tax<, with optional leading ! for negation
-    let mut negate = false;
-    let mut s2 = s;
-    if s2.starts_with('!') {
-        negate = true;
-        s2 = &s2[1..];
-    }
-    if s2.starts_with("tax") {
-        // require nodes map to operate properly
-    if nodes.is_none() {
-            // without taxdump, fall back to simple taxpath string checks (less robust)
-            if s2.starts_with("tax==") {
-                let v = s2[5..].trim();
-                let contains = entry.taxpath.split('|').last().map(|t| t == v).unwrap_or(false);
-                return if negate { !contains } else { contains };
-            }
-            if s2.starts_with("tax<=") {
-                let v = s2[5..].trim();
-                let contains = entry.taxpath.split('|').any(|t| t == v);
-                return if negate { !contains } else { contains };
-            }
-            if s2.starts_with("tax<") {
-                let v = s2[4..].trim();
-                let contains = entry.taxpath.split('|').any(|t| t == v);
-                let eq = entry.taxpath.split('|').last().map(|t| t == v).unwrap_or(false);
-                let res = contains && !eq;
-                return if negate { !res } else { res };
-            }
-            return false;
-        }
-
-        let nodes = nodes.unwrap();
-        let v = if s2.starts_with("tax==") { Some(s2[5..].trim()) } else if s2.starts_with("tax<=") { Some(s2[5..].trim()) } else if s2.starts_with("tax<") { Some(s2[4..].trim()) } else { None };
-        if v.is_none() { return false; }
-        let target = v.unwrap();
-        // Use ancestors map if provided for fast membership checks
-        if let Some(anc) = ancestors {
-            let set = anc.get(&entry.taxid);
-            if s2.starts_with("tax==") {
-                let res = entry.taxid == target;
-                return if negate { !res } else { res };
-            }
-            if s2.starts_with("tax<=") {
-                let res = match set { Some(st) => st.contains(target) || entry.taxid == target, None => false };
-                return if negate { !res } else { res };
-            }
-            if s2.starts_with("tax<") {
-                let res = match set { Some(st) => (st.contains(target) || entry.taxid == target) && entry.taxid != target, None => false };
-                return if negate { !res } else { res };
-            }
-        } else {
-            // fallback: entry.taxid should be used; walk up parents via nodes map
-            let mut cur = entry.taxid.clone();
-            let mut found = false;
-            while let Some((parent, _rank)) = nodes.get(&cur) {
-                if cur == target {
-                    found = true;
-                    break;
-                }
-                if parent == &cur { break; }
-                cur = parent.clone();
-            }
-            if !found && cur == target { found = true; }
-            if s2.starts_with("tax==") {
-                let res = entry.taxid == target;
-                return if negate { !res } else { res };
-            }
-            if s2.starts_with("tax<=") {
-                let res = found || entry.taxid == target;
-                return if negate { !res } else { res };
-            }
-            if s2.starts_with("tax<") {
-                let res = (found || entry.taxid == target) && entry.taxid != target;
-                return if negate { !res } else { res };
-            }
-        }
-    }
-
-    false
-}
-
-fn expr_needs_taxdump(e: &Expr) -> bool {
-    match e {
-        Expr::And(a,b) | Expr::Or(a,b) => expr_needs_taxdump(a) || expr_needs_taxdump(b),
-        Expr::Atom(s) => s.contains("tax"),
-    }
-}
-
-fn write_cami(samples: &Vec<Sample>, out: &mut dyn io::Write) -> Result<()> {
-    for s in samples {
-        writeln!(out, "@SampleID:{}", s.id)?;
-        if let Some(v) = &s.version {
-            writeln!(out, "@Version:{}", v)?;
-        }
-        if !s.ranks.is_empty() {
-            writeln!(out, "@Ranks:{}", s.ranks.join("|"))?;
-        }
-        writeln!(out, "@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE")?;
-        for e in &s.entries {
-            writeln!(out, "{}\t{}\t{}\t{}\t{}", e.taxid, e.rank, e.taxpath, e.taxpathsn, e.percentage)?;
-        }
-    }
-    Ok(())
-}
-
-fn ensure_taxdump(dir: &PathBuf) -> Result<()> {
-    fs::create_dir_all(dir)?;
-    let nodes = dir.join("nodes.dmp");
-    let names = dir.join("names.dmp");
-    if nodes.exists() && names.exists() {
-        return Ok(());
-    }
-    // download taxdump.tar.gz
-    let url = "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz";
-    let resp = get(url)?;
-    let bytes = resp.bytes()?;
-    let gz = GzDecoder::new(&bytes[..]);
-    let mut ar = Archive::new(gz);
-    ar.unpack(dir)?;
-    Ok(())
-}
-
-fn parse_taxdump(dir: &PathBuf) -> Result<(HashMap<String, (String, String)>, HashMap<String, String>)> {
-    // nodes.dmp: taxid\t| parent\t| rank\t| ...
-    let mut nodes = HashMap::new();
-    let mut names = HashMap::new();
-    let nodes_path = dir.join("nodes.dmp");
-    let names_path = dir.join("names.dmp");
-    let f = File::open(&names_path).with_context(|| "opening names.dmp")?;
-    for line in BufReader::new(f).lines() {
-        let l = line?;
-        let parts: Vec<&str> = l.split("\t|\t").collect();
-        if parts.len() >= 2 {
-            let taxid = parts[0].trim().to_string();
-            let name = parts[1].trim().to_string();
-            names.insert(taxid, name);
-        }
-    }
-    let f2 = File::open(&nodes_path).with_context(|| "opening nodes.dmp")?;
-    for line in BufReader::new(f2).lines() {
-        let l = line?;
-        let parts: Vec<&str> = l.split("\t|\t").collect();
-        if parts.len() >= 3 {
-            let taxid = parts[0].trim().to_string();
-            let parent = parts[1].trim().to_string();
-            let rank = parts[2].trim().to_string();
-            nodes.insert(taxid, (parent, rank));
-        }
-    }
-    Ok((nodes, names))
-}
-
-fn lineage(taxid: &str, nodes: &HashMap<String,(String,String)>, names: &HashMap<String,String>) -> Vec<(String,String,String)> {
-    let mut res = Vec::new();
-    let mut cur = taxid.to_string();
-    let mut seen = std::collections::HashSet::new();
-    while !seen.contains(&cur) {
-        seen.insert(cur.clone());
-        if let Some((parent, rank)) = nodes.get(&cur) {
-            let name = names.get(&cur).cloned().unwrap_or_else(|| cur.clone());
-            res.push((cur.clone(), rank.clone(), name));
-            if parent == &cur { break; }
-            cur = parent.clone();
-        } else {
-            // unknown taxid, stop
-            let name = names.get(&cur).cloned().unwrap_or_else(|| cur.clone());
-            res.push((cur.clone(), "no_rank".to_string(), name));
-            break;
-        }
-    }
-    res.reverse();
-    res
-}
-
-fn fill_up_samples(samples: &mut Vec<Sample>, to_rank: &str, nodes: &HashMap<String,(String,String)>, names: &HashMap<String,String>) {
-    for s in samples.iter_mut() {
-        let rank_pos = s.ranks.iter().position(|r| r == to_rank).unwrap_or(0);
-        // accumulate map (taxid, rank) -> percentage
-        let mut acc: HashMap<(String,String), f64> = HashMap::new();
-        for e in &s.entries {
-            // compute lineage for this taxid
-            let lin = lineage(&e.taxid, nodes, names);
-            // create map from rank -> taxid
-            let mut rank_to_taxid: HashMap<String,String> = HashMap::new();
-            for (tid, rnk, _name) in &lin {
-                rank_to_taxid.insert(rnk.clone(), tid.clone());
-            }
-            // for every rank from this entry rank up to to_rank, find ancestor with that rank
-            if let Some(pos_e_rank) = s.ranks.iter().position(|r| r == &e.rank) {
-                for pos in pos_e_rank..=rank_pos {
-                    let target_rank = &s.ranks[pos];
-                    if let Some(taxid_for_rank) = rank_to_taxid.get(target_rank) {
-                        let key = (taxid_for_rank.clone(), target_rank.clone());
-                        *acc.entry(key).or_insert(0.0) += e.percentage;
-                    }
-                }
-            }
-        }
-        // rebuild entries from acc
-        let mut new_entries: Vec<Entry> = Vec::new();
-        for ((tid, rnk), pct) in acc.into_iter() {
-            // build taxpath by walking lineage to tid
-            let lin = lineage(&tid, nodes, names);
-            let taxpath = lin.iter().map(|(t,_,_)| t.clone()).collect::<Vec<_>>().join("|");
-            let taxpathsn = lin.iter().map(|(_,_,n)| n.clone()).collect::<Vec<_>>().join("|");
-            new_entries.push(Entry { taxid: tid, rank: rnk, taxpath, taxpathsn, percentage: pct });
-        }
-        // replace entries
-        s.entries = new_entries;
-    }
-}
-
-fn renormalize(samples: &mut Vec<Sample>) {
-    for s in samples.iter_mut() {
-        let mut by_rank: HashMap<String, Vec<usize>> = HashMap::new();
-        for (i, e) in s.entries.iter().enumerate() {
-            by_rank.entry(e.rank.clone()).or_default().push(i);
-        }
-    for (_r, idxs) in by_rank {
-            let sum: f64 = idxs.iter().map(|&i| s.entries[i].percentage).sum();
-            if sum == 0.0 { continue; }
-            for &i in &idxs {
-                s.entries[i].percentage = s.entries[i].percentage / sum * 100.0;
-            }
-        }
-    }
+    /// Renormalize abundances to 100 per rank for each sample
+    Renorm {
+        /// Input CAMI file
+        #[arg(value_name = "INPUT", index = 1)]
+        input: Option<PathBuf>,
+        /// Output file (defaults to stdout)
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
+    /// Fill up samples to populate missing ranks using taxonomy lineages
+    Fillup {
+        /// Input CAMI file
+        #[arg(value_name = "INPUT", index = 1)]
+        input: Option<PathBuf>,
+        /// Output file (defaults to stdout)
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+        /// Target rank to fill to (inclusive). Defaults to the highest declared rank
+        #[arg(long)]
+        to_rank: Option<String>,
+    },
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match &cli.command {
-        Commands::Filter { expression, output, fill_up, to_rank, renorm, input } => {
-            let input = input.as_ref().cloned().unwrap_or_else(|| PathBuf::from("examples/text.cami"));
-            let samples = parse_cami(&input)?;
-            let expr = parse_expression(expression).with_context(|| "parsing expression")?;
-            let mut out: Box<dyn io::Write> = if let Some(p) = output { Box::new(File::create(p)? ) } else { Box::new(io::stdout()) };
-            let mut filtered: Vec<Sample> = Vec::new();
-            // if expression contains tax atoms, we need to parse taxdump first
-            let needs_taxdump = expr_needs_taxdump(&expr);
-            let (nodes_opt, names_opt, ancestors_opt) = if needs_taxdump || *fill_up {
-                let cami_dir = dirs::home_dir().map(|p| p.join(".cami")).unwrap_or_else(|| PathBuf::from(".cami"));
-                let need_download = !(cami_dir.join("nodes.dmp").exists() && cami_dir.join("names.dmp").exists());
-                if need_download {
-                    eprintln!("downloading taxdump to {}", cami_dir.display());
-                }
-                ensure_taxdump(&cami_dir).with_context(|| format!("ensuring taxdump in {}", cami_dir.display()))?;
-                let (nodes, names) = parse_taxdump(&cami_dir)?;
-                // build ancestors set for each taxid for fast membership queries
-                let mut anc: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
-                for taxid in nodes.keys() {
-                    let mut set = std::collections::HashSet::new();
-                    let mut cur = taxid.clone();
-                    while let Some((parent, _)) = nodes.get(&cur) {
-                        if parent == &cur { break; }
-                        set.insert(parent.clone());
-                        cur = parent.clone();
-                    }
-                    anc.insert(taxid.clone(), set);
-                }
-                (Some(nodes), Some(names), Some(anc))
-            } else {
-                (None, None, None)
+        Commands::Filter {
+            expression,
+            output,
+            fill_up,
+            to_rank,
+            renorm,
+            input,
+        } => {
+            let cfg = FilterConfig {
+                expression,
+                output: output.as_ref(),
+                fill_up: *fill_up,
+                to_rank,
+                renorm: *renorm,
+                input: input.as_ref(),
             };
-
-            for (i, s) in samples.iter().enumerate() {
-                let mut ns = s.clone();
-                ns.entries = ns.entries.into_iter().filter(|e| eval_expr(&expr, &samples, s, e, i, nodes_opt.as_ref(), names_opt.as_ref(), ancestors_opt.as_ref())).collect();
-                filtered.push(ns);
-            }
-            if *fill_up {
-                // ensure taxdump is available and parse it; print message only if we need to download
-                let cami_dir = dirs::home_dir().map(|p| p.join(".cami")).unwrap_or_else(|| PathBuf::from(".cami"));
-                let need_download = !(cami_dir.join("nodes.dmp").exists() && cami_dir.join("names.dmp").exists());
-                if need_download {
-                    eprintln!("downloading taxdump to {}", cami_dir.display());
-                }
-                ensure_taxdump(&cami_dir).with_context(|| format!("ensuring taxdump in {}", cami_dir.display()))?;
-                let (nodes, names) = parse_taxdump(&cami_dir)?;
-                let mut filtered_mut = filtered;
-                fill_up_samples(&mut filtered_mut, to_rank, &nodes, &names);
-                if *renorm { renormalize(&mut filtered_mut); }
-                write_cami(&mut filtered_mut, &mut *out)?;
-            } else {
-                if *renorm { let mut f = filtered.clone(); renormalize(&mut f); write_cami(&f, &mut *out)?; } else { write_cami(&filtered, &mut *out)?; }
-            }
-        }
-        Commands::Preview { n, input } => {
-            let input = input.as_ref().cloned().unwrap_or_else(|| PathBuf::from("examples/text.cami"));
-            let samples = parse_cami(&input)?;
-            let mut out = io::stdout();
-            for s in &samples {
-                writeln!(out, "@SampleID:{}", s.id)?;
-                if let Some(v) = &s.version { writeln!(out, "@Version:{}", v)?; }
-                if !s.ranks.is_empty() { writeln!(out, "@Ranks:{}", s.ranks.join("|"))?; }
-                writeln!(out, "@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE")?;
-                for e in s.entries.iter().take(*n) {
-                    writeln!(out, "{}\t{}\t{}\t{}\t{}", e.taxid, e.rank, e.taxpath, e.taxpathsn, e.percentage)?;
-                }
-            }
+            filter_cmd::run(&cfg)
         }
         Commands::List { input } => {
-            let input = input.as_ref().cloned().unwrap_or_else(|| PathBuf::from("examples/text.cami"));
-            let samples = parse_cami(&input)?;
-            let mut out = io::stdout();
-            for s in &samples {
-                writeln!(out, "Sample: {}", s.id)?;
-                writeln!(out, "  Ranks: {}", s.ranks.join(", "))?;
-                writeln!(out, "  Taxa: {}", s.entries.len())?;
-                // totals per rank
-                let mut totals: HashMap<String,f64> = HashMap::new();
-                for e in &s.entries { *totals.entry(e.rank.clone()).or_insert(0.0) += e.percentage; }
-                for r in &s.ranks {
-                    let t = totals.get(r).cloned().unwrap_or(0.0);
-                    writeln!(out, "    {}: {:.6}", r, t)?;
-                }
-            }
+            let cfg = ListConfig {
+                input: input.as_ref(),
+            };
+            list_cmd::run(&cfg)
+        }
+        Commands::Preview { n, input } => {
+            let cfg = PreviewConfig {
+                n: *n,
+                input: input.as_ref(),
+            };
+            preview_cmd::run(&cfg)
+        }
+        Commands::Renorm { input, output } => {
+            let cfg = RenormConfig {
+                input: input.as_ref(),
+                output: output.as_ref(),
+            };
+            renorm_cmd::run(&cfg)
+        }
+        Commands::Fillup {
+            input,
+            output,
+            to_rank,
+        } => {
+            let cfg = FillupConfig {
+                input: input.as_ref(),
+                output: output.as_ref(),
+                to_rank: to_rank.as_deref(),
+            };
+            fillup_cmd::run(&cfg)
         }
     }
-
-    Ok(())
 }

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -1,0 +1,217 @@
+use crate::cami::{Entry, Sample};
+use crate::taxonomy::{Taxonomy, parse_taxid};
+use std::collections::{BTreeSet, HashMap};
+
+pub fn renormalize(samples: &mut [Sample]) {
+    for sample in samples.iter_mut() {
+        let mut by_rank: HashMap<String, Vec<usize>> = HashMap::new();
+        for (idx, entry) in sample.entries.iter().enumerate() {
+            by_rank.entry(entry.rank.clone()).or_default().push(idx);
+        }
+        for idxs in by_rank.values() {
+            let sum: f64 = idxs
+                .iter()
+                .map(|&i| {
+                    let v = sample.entries[i].percentage;
+                    if v > 0.0 { v } else { 0.0 }
+                })
+                .sum();
+            if sum <= 0.0 {
+                continue;
+            }
+            for &i in idxs {
+                if sample.entries[i].percentage > 0.0 {
+                    sample.entries[i].percentage = sample.entries[i].percentage / sum * 100.0;
+                }
+            }
+        }
+    }
+}
+
+pub fn fill_up_to(samples: &mut [Sample], to_rank: &str, taxonomy: &Taxonomy) {
+    for sample in samples.iter_mut() {
+        if sample.entries.is_empty() {
+            continue;
+        }
+        let Some(target_idx) = sample.rank_index(to_rank) else {
+            continue;
+        };
+
+        let mut existing_by_key: HashMap<(usize, String), Entry> = HashMap::new();
+        let mut existing_by_rank: HashMap<usize, Vec<String>> = HashMap::new();
+        for entry in &sample.entries {
+            if let Some(idx) = sample.rank_index(&entry.rank) {
+                existing_by_key
+                    .entry((idx, entry.taxid.clone()))
+                    .or_insert_with(|| entry.clone());
+                existing_by_rank
+                    .entry(idx)
+                    .or_default()
+                    .push(entry.taxid.clone());
+            }
+        }
+
+        let mut sums: HashMap<(usize, String), f64> = HashMap::new();
+        let mut cache: HashMap<String, HashMap<String, (String, String)>> = HashMap::new();
+
+        for entry in &sample.entries {
+            let Some(entry_rank_idx) = sample.rank_index(&entry.rank) else {
+                continue;
+            };
+            let fallback_entry = existing_by_key.get(&(entry_rank_idx, entry.taxid.clone()));
+            let Some(rank_map) = rank_map_for(sample, taxonomy, &entry.taxid, &mut cache, || {
+                fallback_entry.and_then(|e| fallback_rank_map(e, sample))
+            }) else {
+                continue;
+            };
+
+            let start = entry_rank_idx.min(target_idx);
+            let end = entry_rank_idx.max(target_idx);
+            for rank in &sample.ranks[start..=end] {
+                if let Some((tid, _name)) = rank_map.get(rank) {
+                    if let Some(idx) = sample.rank_index(rank) {
+                        *sums.entry((idx, tid.clone())).or_insert(0.0) += entry.percentage;
+                    }
+                }
+            }
+        }
+
+        let mut new_entries: Vec<Entry> = Vec::new();
+        for (idx, rank) in sample.ranks.iter().enumerate() {
+            let mut taxids: BTreeSet<String> = BTreeSet::new();
+            if let Some(existing) = existing_by_rank.get(&idx) {
+                for taxid in existing {
+                    taxids.insert(taxid.clone());
+                }
+            }
+            for ((s_idx, taxid), pct) in &sums {
+                if *s_idx == idx && *pct > 0.0 {
+                    taxids.insert(taxid.clone());
+                }
+            }
+
+            for taxid in taxids {
+                let existing_entry = existing_by_key.get(&(idx, taxid.clone()));
+                let percentage = existing_entry
+                    .map(|e| e.percentage)
+                    .unwrap_or_else(|| *sums.get(&(idx, taxid.clone())).unwrap_or(&0.0));
+                if percentage <= 0.0 {
+                    continue;
+                }
+
+                let Some(rank_map) = rank_map_for(sample, taxonomy, &taxid, &mut cache, || {
+                    existing_entry.and_then(|e| fallback_rank_map(e, sample))
+                }) else {
+                    if let Some(entry) = existing_entry {
+                        new_entries.push(entry.clone());
+                    }
+                    continue;
+                };
+                if !rank_map.contains_key(rank) {
+                    if let Some(entry) = existing_entry {
+                        new_entries.push(entry.clone());
+                    }
+                    continue;
+                }
+                let (taxpath, taxpathsn) = build_paths(sample, &rank_map, rank);
+                new_entries.push(Entry {
+                    taxid: taxid.clone(),
+                    rank: rank.clone(),
+                    taxpath,
+                    taxpathsn,
+                    percentage,
+                });
+            }
+        }
+
+        sample.entries = new_entries;
+    }
+}
+
+pub fn fill_up_default(samples: &mut [Sample], taxonomy: &Taxonomy) {
+    for sample in samples.iter_mut() {
+        if sample.entries.is_empty() {
+            continue;
+        }
+        if let Some(target_rank) = sample.ranks.first().cloned() {
+            fill_up_to(std::slice::from_mut(sample), &target_rank, taxonomy);
+        }
+    }
+}
+
+fn rank_map_for<'a, F>(
+    sample: &Sample,
+    taxonomy: &Taxonomy,
+    taxid: &str,
+    cache: &'a mut HashMap<String, HashMap<String, (String, String)>>,
+    mut fallback: F,
+) -> Option<&'a HashMap<String, (String, String)>>
+where
+    F: FnMut() -> Option<HashMap<String, (String, String)>>,
+{
+    if !cache.contains_key(taxid) {
+        if let Some(map) = build_rank_map(sample, taxonomy, taxid) {
+            cache.insert(taxid.to_string(), map);
+        } else if let Some(map) = fallback() {
+            cache.insert(taxid.to_string(), map);
+        } else {
+            cache.insert(taxid.to_string(), HashMap::new());
+        }
+    }
+    let map = cache.get(taxid)?;
+    if map.is_empty() { None } else { Some(map) }
+}
+
+fn build_rank_map(
+    sample: &Sample,
+    taxonomy: &Taxonomy,
+    taxid: &str,
+) -> Option<HashMap<String, (String, String)>> {
+    let tid = parse_taxid(taxid)?;
+    let lineage = taxonomy.lineage(tid);
+    let mut map = HashMap::new();
+    for (tid_u32, rank, name) in lineage {
+        if sample.ranks.iter().any(|r| r == &rank) {
+            map.insert(rank, (tid_u32.to_string(), name));
+        }
+    }
+    if map.is_empty() { None } else { Some(map) }
+}
+
+fn fallback_rank_map(entry: &Entry, sample: &Sample) -> Option<HashMap<String, (String, String)>> {
+    let ids: Vec<&str> = entry.taxpath.split('|').collect();
+    let names: Vec<&str> = entry.taxpathsn.split('|').collect();
+    if ids.is_empty() || names.is_empty() {
+        return None;
+    }
+    let mut map = HashMap::new();
+    let upto = ids.len().min(names.len()).min(sample.ranks.len());
+    for idx in 0..upto {
+        let rank = &sample.ranks[idx];
+        let taxid = ids[idx].trim();
+        let name = names[idx].trim();
+        if !taxid.is_empty() {
+            map.insert(rank.clone(), (taxid.to_string(), name.to_string()));
+        }
+    }
+    if map.is_empty() { None } else { Some(map) }
+}
+
+fn build_paths(
+    sample: &Sample,
+    rank_map: &HashMap<String, (String, String)>,
+    upto_rank: &str,
+) -> (String, String) {
+    let mut taxids = Vec::new();
+    let mut names = Vec::new();
+    for rank in &sample.ranks {
+        if let Some((tid, name)) = rank_map.get(rank) {
+            taxids.push(tid.clone());
+            names.push(name.clone());
+        }
+        if rank == upto_rank {
+            break;
+        }
+    }
+    (taxids.join("|"), names.join("|"))
+}

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -1,0 +1,194 @@
+use anyhow::{Context, Result, anyhow};
+use flate2::read::GzDecoder;
+use reqwest::blocking::get;
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::sync::RwLock;
+use std::thread;
+use tar::Archive;
+
+#[derive(Debug, Clone)]
+pub struct TaxNode {
+    pub parent: u32,
+    pub rank: String,
+}
+
+#[derive(Debug)]
+pub struct Taxonomy {
+    nodes: HashMap<u32, TaxNode>,
+    names: HashMap<u32, String>,
+    ancestors: RwLock<HashMap<u32, Vec<u32>>>,
+    lineages: RwLock<HashMap<u32, Vec<(u32, String, String)>>>,
+}
+
+impl Taxonomy {
+    pub fn load(dir: &Path) -> Result<Self> {
+        let nodes_path = dir.join("nodes.dmp");
+        let names_path = dir.join("names.dmp");
+
+        let nodes_handle = {
+            let path = nodes_path.clone();
+            thread::spawn(move || parse_nodes(&path))
+        };
+        let names_handle = {
+            let path = names_path.clone();
+            thread::spawn(move || parse_names(&path))
+        };
+
+        let nodes = nodes_handle
+            .join()
+            .map_err(|_| anyhow!("failed to parse nodes.dmp"))??;
+        let names = names_handle
+            .join()
+            .map_err(|_| anyhow!("failed to parse names.dmp"))??;
+
+        Ok(Self {
+            nodes,
+            names,
+            ancestors: RwLock::new(HashMap::new()),
+            lineages: RwLock::new(HashMap::new()),
+        })
+    }
+
+    pub fn ancestors_of(&self, taxid: u32) -> Vec<u32> {
+        if let Some(cached) = self.ancestors.read().unwrap().get(&taxid) {
+            return cached.clone();
+        }
+
+        let mut lineage = Vec::new();
+        let mut current = taxid;
+        let mut seen = HashSet::new();
+        while let Some(node) = self.nodes.get(&current) {
+            if node.parent == current || seen.contains(&current) {
+                break;
+            }
+            seen.insert(current);
+            lineage.push(node.parent);
+            current = node.parent;
+        }
+
+        self.ancestors
+            .write()
+            .unwrap()
+            .insert(taxid, lineage.clone());
+        lineage
+    }
+
+    pub fn lineage(&self, taxid: u32) -> Vec<(u32, String, String)> {
+        if let Some(cached) = self.lineages.read().unwrap().get(&taxid) {
+            return cached.clone();
+        }
+        let mut stack = Vec::new();
+        let mut current = Some(taxid);
+        let mut visited = HashSet::new();
+        while let Some(tid) = current {
+            if visited.contains(&tid) {
+                break;
+            }
+            visited.insert(tid);
+            let rank_raw = self
+                .nodes
+                .get(&tid)
+                .map(|n| n.rank.clone())
+                .unwrap_or_else(|| "no_rank".to_string());
+            let rank = canonicalize_rank(&rank_raw);
+            let name = self
+                .names
+                .get(&tid)
+                .cloned()
+                .unwrap_or_else(|| tid.to_string());
+            stack.push((tid, rank, name));
+            current = self.nodes.get(&tid).and_then(|n| {
+                if n.parent == tid {
+                    None
+                } else {
+                    Some(n.parent)
+                }
+            });
+        }
+        stack.reverse();
+        self.lineages.write().unwrap().insert(taxid, stack.clone());
+        stack
+    }
+}
+
+pub fn ensure_taxdump(dir: &Path) -> Result<()> {
+    fs::create_dir_all(dir)?;
+    let nodes = dir.join("nodes.dmp");
+    let names = dir.join("names.dmp");
+    if nodes.exists() && names.exists() {
+        return Ok(());
+    }
+    let url = "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz";
+    let resp = get(url)?;
+    let bytes = resp.bytes()?;
+    let gz = GzDecoder::new(&bytes[..]);
+    let mut ar = Archive::new(gz);
+    ar.unpack(dir)?;
+    Ok(())
+}
+
+fn parse_nodes(path: &Path) -> Result<HashMap<u32, TaxNode>> {
+    let file = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut nodes = HashMap::new();
+    for line in reader.lines() {
+        let l = line?;
+        let parts: Vec<&str> = l.split('|').collect();
+        if parts.len() < 3 {
+            continue;
+        }
+        let taxid: u32 = parts[0]
+            .trim_matches(|c: char| c.is_whitespace())
+            .parse()
+            .unwrap_or(0);
+        let parent: u32 = parts[1]
+            .trim_matches(|c: char| c.is_whitespace())
+            .parse()
+            .unwrap_or(taxid);
+        let rank = parts[2]
+            .trim_matches(|c: char| c.is_whitespace())
+            .to_string();
+        nodes.insert(taxid, TaxNode { parent, rank });
+    }
+    Ok(nodes)
+}
+
+fn parse_names(path: &Path) -> Result<HashMap<u32, String>> {
+    let file = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut names = HashMap::new();
+    for line in reader.lines() {
+        let l = line?;
+        let parts: Vec<&str> = l.split('|').collect();
+        if parts.len() < 4 {
+            continue;
+        }
+        let taxid: u32 = parts[0]
+            .trim_matches(|c: char| c.is_whitespace())
+            .parse()
+            .unwrap_or(0);
+        let name = parts[1]
+            .trim_matches(|c: char| c.is_whitespace())
+            .to_string();
+        let class = parts[3].trim_matches(|c: char| c.is_whitespace());
+        if class != "scientific name" {
+            continue;
+        }
+        names.entry(taxid).or_insert(name);
+    }
+    Ok(names)
+}
+
+pub fn parse_taxid(taxid: &str) -> Option<u32> {
+    taxid.parse().ok()
+}
+
+fn canonicalize_rank(rank: &str) -> String {
+    match rank {
+        "domain" => "superkingdom".to_string(),
+        other => other.to_string(),
+    }
+}


### PR DESCRIPTION
## Summary
- cache taxonomy lineages and map domain ranks to superkingdom so fill-up emits the header-defined ranks
- rebuild fill-up aggregation to reuse existing parent abundances while deriving only missing ancestors from taxonomy lineages
- enhance filter parsing for multi-rank equality, quoted/ranged sample selectors, and round list totals to three decimals

## Testing
- cargo fmt
- cargo build
- cargo run -- filter "abundance>20 & sample==s1" examples/test.cami
- cargo run -- filter "r==species,genus & a>20 & s==s1" examples/test.cami
- cargo run -- filter "s==:2" examples/test.cami
- cargo run -- list examples/test.cami
- cargo run -- filter "abundance>20 & sample==s1 & r==species" examples/test.cami --fill-up *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68e1211185d8832ab528f43621e73033