### PR TITLE
Add sort command and round fillup abundances

### DIFF
--- a/src/commands/fillup.rs
+++ b/src/commands/fillup.rs
@@ -1,5 +1,5 @@
 use crate::cami::{load_samples, open_output, write_cami};
-use crate::processing::{fill_up_default, fill_up_to};
+use crate::processing::{fill_up_default, fill_up_to, round_percentages};
 use crate::taxonomy::{Taxonomy, ensure_taxdump};
 use anyhow::{Context, Result};
 use std::path::PathBuf;
@@ -22,6 +22,8 @@ pub fn run(cfg: &FillupConfig) -> Result<()> {
     } else {
         fill_up_default(&mut samples, cfg.from_rank, &taxonomy);
     }
+
+    round_percentages(&mut samples);
 
     let mut out = open_output(cfg.output)?;
     write_cami(&samples, &mut *out)?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod filter;
 pub mod list;
 pub mod preview;
 pub mod renorm;
+pub mod sort;

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -1,0 +1,94 @@
+use crate::cami::{Entry, load_samples, open_output, write_cami};
+use anyhow::Result;
+use clap::ValueEnum;
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+#[derive(Clone, Copy)]
+pub enum SortMode {
+    Abundance,
+    TaxPath(TaxPathField),
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum TaxPathField {
+    #[value(alias = "taxpath")]
+    Taxpath,
+    #[value(alias = "taxpathsn")]
+    Taxpathsn,
+}
+
+impl TaxPathField {
+    fn key<'a>(&self, entry: &'a Entry) -> &'a str {
+        match self {
+            TaxPathField::Taxpath => &entry.taxpath,
+            TaxPathField::Taxpathsn => &entry.taxpathsn,
+        }
+    }
+}
+
+pub struct SortConfig<'a> {
+    pub input: Option<&'a PathBuf>,
+    pub output: Option<&'a PathBuf>,
+    pub mode: SortMode,
+}
+
+pub fn run(cfg: &SortConfig) -> Result<()> {
+    let mut samples = load_samples(cfg.input)?;
+
+    for sample in samples.iter_mut() {
+        let entries = std::mem::take(&mut sample.entries);
+        let mut by_rank: HashMap<String, Vec<Entry>> = HashMap::new();
+        for entry in entries {
+            by_rank.entry(entry.rank.clone()).or_default().push(entry);
+        }
+
+        let mut ordered_ranks = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        for rank in &sample.ranks {
+            if seen.insert(rank.clone()) {
+                ordered_ranks.push(rank.clone());
+            }
+        }
+        for rank in by_rank.keys() {
+            if seen.insert(rank.clone()) {
+                ordered_ranks.push(rank.clone());
+            }
+        }
+
+        let mut new_entries = Vec::new();
+        for rank in ordered_ranks {
+            if let Some(mut entries) = by_rank.remove(&rank) {
+                match cfg.mode {
+                    SortMode::Abundance => {
+                        entries.retain(|e| e.percentage > 0.0);
+                        entries.sort_by(|a, b| {
+                            match b
+                                .percentage
+                                .partial_cmp(&a.percentage)
+                                .unwrap_or(Ordering::Equal)
+                            {
+                                Ordering::Equal => a.taxid.cmp(&b.taxid),
+                                other => other,
+                            }
+                        });
+                    }
+                    SortMode::TaxPath(field) => {
+                        entries.sort_by(|a, b| {
+                            let key_a = field.key(a);
+                            let key_b = field.key(b);
+                            key_a.cmp(key_b).then_with(|| a.taxid.cmp(&b.taxid))
+                        });
+                    }
+                }
+                new_entries.extend(entries);
+            }
+        }
+        sample.entries = new_entries;
+    }
+
+    let mut out = open_output(cfg.output)?;
+    write_cami(&samples, &mut *out)?;
+    Ok(())
+}

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -29,6 +29,14 @@ pub fn renormalize(samples: &mut [Sample]) {
     }
 }
 
+pub fn round_percentages(samples: &mut [Sample]) {
+    for sample in samples.iter_mut() {
+        for entry in &mut sample.entries {
+            entry.percentage = (entry.percentage * 100000.0).round() / 100000.0;
+        }
+    }
+}
+
 pub fn fill_up_to(
     samples: &mut [Sample],
     from_rank: Option<&str>,


### PR DESCRIPTION
## Summary
- add a sort subcommand to order taxa within each rank by abundance or taxonomy path
- remove zero-abundance taxa when sorting by abundance and support choosing TAXPATH or TAXPATHSN
- round filled-up abundances to five decimal places before writing output

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68e1503b4d28832ab517bcacb01e3426