### PR TITLE
Ensure benchmark TSV formatting matches requirements

### DIFF
--- a/src/commands/benchmark.rs
+++ b/src/commands/benchmark.rs
@@ -25,7 +25,6 @@ struct ProfileEntry {
     taxid: String,
     percentage: f64,
     taxpath: String,
-    taxpathsn: String,
 }
 
 pub fn run(cfg: &BenchmarkConfig) -> Result<()> {
@@ -194,7 +193,6 @@ fn build_profile_map(
                     taxid: entry.taxid.clone(),
                     percentage: entry.percentage,
                     taxpath: entry.taxpath.clone(),
-                    taxpathsn: entry.taxpathsn.clone(),
                 });
         }
 
@@ -509,5 +507,5 @@ fn format_opt(value: Option<f64>) -> String {
 }
 
 fn format_float(value: f64) -> String {
-    format!("{:.6}", value)
+    format!("{:.5}", value)
 }


### PR DESCRIPTION
## Summary
- drop the unused `taxpathsn` field from benchmark profile entries
- emit benchmark metrics rounded to five decimal places to satisfy the reporting requirements

## Testing
- cargo test *(fails: unable to download crates index in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1804665dc832a9df5440f20212dea