### PR TITLE
Improve taxonomy caching and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,12 +129,13 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cami"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
  "dirs",
  "flate2",
+ "regex",
  "reqwest",
  "tar",
 ]
@@ -911,6 +921,35 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cami"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -638,10 +638,8 @@ fn eval_taxonomy(entry: &Entry, taxonomy: &Taxonomy, op: &str, value: &str) -> b
                 if e == t {
                     return true;
                 }
-                taxonomy
-                    .ancestors_of(e)
-                    .iter()
-                    .any(|ancestor| *ancestor == t)
+                let ancestors = taxonomy.ancestors_of(e);
+                ancestors.iter().any(|ancestor| *ancestor == t)
             } else {
                 entry.taxpath.split('|').any(|tid| tid == value)
             }
@@ -651,10 +649,8 @@ fn eval_taxonomy(entry: &Entry, taxonomy: &Taxonomy, op: &str, value: &str) -> b
                 if e == t {
                     return false;
                 }
-                taxonomy
-                    .ancestors_of(e)
-                    .iter()
-                    .any(|ancestor| *ancestor == t)
+                let ancestors = taxonomy.ancestors_of(e);
+                ancestors.iter().any(|ancestor| *ancestor == t)
             } else {
                 entry
                     .taxpath

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -229,9 +229,9 @@ fn build_rank_map(
     let tid = parse_taxid(taxid)?;
     let lineage = taxonomy.lineage(tid);
     let mut map = HashMap::new();
-    for (tid_u32, rank, name) in lineage {
-        if sample.ranks.iter().any(|r| r == &rank) {
-            map.insert(rank, (tid_u32.to_string(), name));
+    for (tid_u32, rank, name) in lineage.iter() {
+        if sample.ranks.iter().any(|r| r == rank) {
+            map.insert(rank.clone(), (tid_u32.to_string(), name.clone()));
         }
     }
     if map.is_empty() { None } else { Some(map) }

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use std::thread;
 use tar::Archive;
 
@@ -15,12 +15,15 @@ pub struct TaxNode {
     pub rank: String,
 }
 
+type LineageEntry = (u32, String, String);
+
 #[derive(Debug)]
 pub struct Taxonomy {
     nodes: HashMap<u32, TaxNode>,
     names: HashMap<u32, String>,
-    ancestors: RwLock<HashMap<u32, Vec<u32>>>,
-    lineages: RwLock<HashMap<u32, Vec<(u32, String, String)>>>,
+    ancestors: RwLock<HashMap<u32, Arc<[u32]>>>,
+    lineages: RwLock<HashMap<u32, Arc<[LineageEntry]>>>,
+    superkingdoms: RwLock<HashMap<u32, Option<String>>>,
 }
 
 impl Taxonomy {
@@ -49,10 +52,11 @@ impl Taxonomy {
             names,
             ancestors: RwLock::new(HashMap::new()),
             lineages: RwLock::new(HashMap::new()),
+            superkingdoms: RwLock::new(HashMap::new()),
         })
     }
 
-    pub fn ancestors_of(&self, taxid: u32) -> Vec<u32> {
+    pub fn ancestors_of(&self, taxid: u32) -> Arc<[u32]> {
         if let Some(cached) = self.ancestors.read().unwrap().get(&taxid) {
             return cached.clone();
         }
@@ -69,14 +73,15 @@ impl Taxonomy {
             current = node.parent;
         }
 
+        let cached: Arc<[u32]> = lineage.into_boxed_slice().into();
         self.ancestors
             .write()
             .unwrap()
-            .insert(taxid, lineage.clone());
-        lineage
+            .insert(taxid, cached.clone());
+        cached
     }
 
-    pub fn lineage(&self, taxid: u32) -> Vec<(u32, String, String)> {
+    pub fn lineage(&self, taxid: u32) -> Arc<[LineageEntry]> {
         if let Some(cached) = self.lineages.read().unwrap().get(&taxid) {
             return cached.clone();
         }
@@ -88,12 +93,11 @@ impl Taxonomy {
                 break;
             }
             visited.insert(tid);
-            let rank_raw = self
+            let rank = self
                 .nodes
                 .get(&tid)
                 .map(|n| n.rank.clone())
                 .unwrap_or_else(|| "no_rank".to_string());
-            let rank = canonicalize_rank(&rank_raw);
             let name = self
                 .names
                 .get(&tid)
@@ -109,8 +113,27 @@ impl Taxonomy {
             });
         }
         stack.reverse();
-        self.lineages.write().unwrap().insert(taxid, stack.clone());
-        stack
+        let cached: Arc<[LineageEntry]> = stack.into_boxed_slice().into();
+        self.lineages.write().unwrap().insert(taxid, cached.clone());
+        cached
+    }
+
+    pub fn superkingdom_of(&self, taxid: u32) -> Option<String> {
+        if let Some(cached) = self.superkingdoms.read().unwrap().get(&taxid) {
+            return cached.clone();
+        }
+
+        let lineage = self.lineage(taxid);
+        let result = lineage
+            .iter()
+            .find(|(_, rank, _)| rank == "superkingdom")
+            .map(|(_, _, name)| name.clone());
+
+        self.superkingdoms
+            .write()
+            .unwrap()
+            .insert(taxid, result.clone());
+        result
     }
 }
 
@@ -148,10 +171,14 @@ fn parse_nodes(path: &Path) -> Result<HashMap<u32, TaxNode>> {
             .trim_matches(|c: char| c.is_whitespace())
             .parse()
             .unwrap_or(taxid);
-        let rank = parts[2]
-            .trim_matches(|c: char| c.is_whitespace())
-            .to_string();
-        nodes.insert(taxid, TaxNode { parent, rank });
+        let rank = parts[2].trim_matches(|c: char| c.is_whitespace());
+        nodes.insert(
+            taxid,
+            TaxNode {
+                parent,
+                rank: canonicalize_rank(rank),
+            },
+        );
     }
     Ok(nodes)
 }


### PR DESCRIPTION
## Summary
- bump the crate version to 0.4.0
- cache taxonomy ancestry and lineage data with shared slices so repeated lookups, including superkingdom inference, reuse prior work across commands
- update expression and processing helpers to consume the shared taxonomy caches

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e8cdb4dc74832aa51dcaeb1db10c2b