### PR TITLE
Preserve double precision for abundance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ When `--fill-up` is supplied, the command downloads the NCBI taxdump (stored und
 
 ### `cami fillup`
 
-Populate missing higher ranks for every sample using the NCBI taxdump. Abundances are rounded to five decimal places once the hierarchy is filled.
+Populate missing higher ranks for every sample using the NCBI taxdump. Abundances retain their full precision after the hierarchy is filled.
 
 ```bash
 cami fillup --to-rank family examples/test.cami > with_family.cami
@@ -111,7 +111,7 @@ If `--to-rank` is omitted, the command fills to the highest rank declared in eac
 
 ### `cami renorm`
 
-Renormalize abundances so that the percentages at each rank sum to 100 for every sample. Entries with zero or negative abundances are ignored during scaling, and positive values are rounded to five decimal places.
+Renormalize abundances so that the percentages at each rank sum to 100 for every sample. Entries with zero or negative abundances are ignored during scaling, and positive values keep their full double-precision values.
 
 ```bash
 cami renorm examples/test.cami > renormalized.cami

--- a/src/commands/benchmark.rs
+++ b/src/commands/benchmark.rs
@@ -271,7 +271,6 @@ fn build_profile_map(
                 if sum > 0.0 {
                     for entry in entries.iter_mut() {
                         entry.percentage = entry.percentage / sum * 100.0;
-                        entry.percentage = (entry.percentage * 100000.0).round() / 100000.0;
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ enum Commands {
     },
     #[command(
         about = "Renormalize abundances per rank",
-        long_about = "Scale positive abundances within each rank of every sample so they sum to 100 and round the results to five decimal places."
+        long_about = "Scale positive abundances within each rank of every sample so they sum to 100 without altering their precision."
     )]
     Renorm {
         #[arg(
@@ -218,7 +218,7 @@ enum Commands {
     },
     #[command(
         about = "Fill missing ranks using taxonomy",
-        long_about = "Complete partial lineages in each sample by consulting the NCBI taxdump. Newly created abundances are rounded to five decimal places so the output stays tidy."
+        long_about = "Complete partial lineages in each sample by consulting the NCBI taxdump while preserving the numeric precision of existing abundances."
     )]
     Fillup {
         #[arg(

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -21,8 +21,7 @@ pub fn renormalize(samples: &mut [Sample]) {
             }
             for &i in idxs {
                 if sample.entries[i].percentage > 0.0 {
-                    let normalized = sample.entries[i].percentage / sum * 100.0;
-                    sample.entries[i].percentage = (normalized * 100000.0).round() / 100000.0;
+                    sample.entries[i].percentage = sample.entries[i].percentage / sum * 100.0;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- stop rounding normalized abundances so L1 and Bray–Curtis use the full precision inputs
- update the CLI help and README to reflect that normalization now preserves precision

## Testing
- cargo fmt
- cargo test *(fails: unable to download crates due to 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68eac9351da4832a8d75838134060d84