### PR TITLE
Prefer taxid lineage for UniFrac tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cami"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Summary
- build UniFrac tree branches from taxid-based lineages so synonyms share the same path
- fall back to name-based taxpaths only when numeric taxids are unavailable and add a regression test for synonym handling

## Testing
- cargo fmt
- cargo test
- cargo run -- benchmark -g examples/gt_marine_s0.cami examples/pd_marine_s0.cami -o /tmp/out

------
https://chatgpt.com/codex/tasks/task_e_68eb9e9d00d0832aa99f37a0f2593774