### PR TITLE
Add taxonomy update support to benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cami"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,12 @@ enum Commands {
         )]
         predictions: Vec<PathBuf>,
         #[arg(
+            short = 'u',
+            long = "update-taxonomy",
+            help = "Refresh taxonomy fields from the local NCBI taxdump when benchmarking."
+        )]
+        update_taxonomy: bool,
+        #[arg(
             short = 'l',
             long = "labels",
             value_name = "LABELS",
@@ -277,6 +283,7 @@ fn main() -> Result<()> {
         Commands::Benchmark {
             ground_truth,
             predictions,
+            update_taxonomy,
             labels,
             all_filter,
             ground_filter,
@@ -291,6 +298,7 @@ fn main() -> Result<()> {
             let cfg = BenchmarkRunConfig {
                 ground_truth: ground_truth.clone(),
                 predictions: predictions.clone(),
+                update_taxonomy: *update_taxonomy,
                 labels: label_vec,
                 all_filter: all_filter.clone(),
                 ground_filter: ground_filter.clone(),


### PR DESCRIPTION
## Summary
- add a `--update-taxonomy` flag to the benchmark CLI to refresh CAMI taxonomy metadata from the local taxdump
- rebuild benchmark processing to update taxonomy paths with cached lineage lookups and to backfill missing superkingdoms when needed
- cover the new helpers with unit tests for superkingdom detection and path prefixing

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ebc747064c832ab0d7b0fde3ccb39e