### PR TITLE
Add modern CAMI support, TSV converter, and taxonomy overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cami"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cami"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 
 [dependencies]

--- a/src/cami.rs
+++ b/src/cami.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -8,6 +9,8 @@ pub struct Sample {
     pub id: String,
     pub version: Option<String>,
     pub ranks: Vec<String>,
+    pub rank_groups: Vec<Vec<String>>,
+    pub rank_aliases: HashMap<String, usize>,
     pub entries: Vec<Entry>,
 }
 
@@ -18,12 +21,75 @@ pub struct Entry {
     pub taxpath: String,
     pub taxpathsn: String,
     pub percentage: f64,
+    pub cami_genome_id: Option<String>,
+    pub cami_otu: Option<String>,
+    pub hosts: Option<String>,
 }
 
 impl Sample {
     pub fn rank_index(&self, rank: &str) -> Option<usize> {
-        self.ranks.iter().position(|r| r == rank)
+        self.rank_aliases.get(rank).copied()
     }
+
+    pub fn header_rank_tokens(&self) -> Vec<String> {
+        self.rank_groups
+            .iter()
+            .map(|group| {
+                if group.len() == 1 {
+                    group[0].clone()
+                } else {
+                    format!("{{{}}}", group.join(", "))
+                }
+            })
+            .collect()
+    }
+
+    pub fn is_modern_format(&self) -> bool {
+        self.rank_groups.iter().any(|g| g.len() > 1)
+    }
+
+    pub fn set_rank_groups(&mut self, groups: Vec<Vec<String>>) {
+        self.rank_groups = groups
+            .into_iter()
+            .map(|group| {
+                group
+                    .into_iter()
+                    .map(|name| name.trim().to_string())
+                    .filter(|name| !name.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|group| !group.is_empty())
+            .collect();
+        self.ranks = self
+            .rank_groups
+            .iter()
+            .map(|group| group.first().cloned().unwrap_or_default())
+            .collect();
+        self.rank_aliases.clear();
+        for (idx, group) in self.rank_groups.iter().enumerate() {
+            for name in group {
+                self.rank_aliases.insert(name.clone(), idx);
+            }
+        }
+    }
+}
+
+fn parse_rank_groups(spec: &str) -> Vec<Vec<String>> {
+    spec.split('|')
+        .map(|part| {
+            let trimmed = part.trim();
+            if let Some(stripped) = trimmed.strip_prefix('{') {
+                if let Some(inner) = stripped.strip_suffix('}') {
+                    return inner
+                        .split(',')
+                        .map(|name| name.trim().to_string())
+                        .filter(|name| !name.is_empty())
+                        .collect();
+                }
+            }
+            vec![trimmed.to_string()]
+        })
+        .collect()
 }
 
 pub fn parse_cami_reader<R: BufRead>(reader: R) -> Result<Vec<Sample>> {
@@ -45,6 +111,8 @@ pub fn parse_cami_reader<R: BufRead>(reader: R) -> Result<Vec<Sample>> {
                 id,
                 version: None,
                 ranks: Vec::new(),
+                rank_groups: Vec::new(),
+                rank_aliases: HashMap::new(),
                 entries: Vec::new(),
             });
             continue;
@@ -57,12 +125,8 @@ pub fn parse_cami_reader<R: BufRead>(reader: R) -> Result<Vec<Sample>> {
         }
         if line.starts_with("@Ranks:") {
             if let Some(s) = current.as_mut() {
-                let ranks = line[7..]
-                    .trim()
-                    .split('|')
-                    .map(|r| r.trim().to_string())
-                    .collect();
-                s.ranks = ranks;
+                let groups = parse_rank_groups(line[7..].trim());
+                s.set_rank_groups(groups);
             }
             continue;
         }
@@ -71,21 +135,30 @@ pub fn parse_cami_reader<R: BufRead>(reader: R) -> Result<Vec<Sample>> {
         }
 
         let fields: Vec<&str> = line.split('\t').collect();
-        let (taxid, rank, taxpath, taxpathsn, percentage) = if fields.len() >= 5 {
-            (fields[0], fields[1], fields[2], fields[3], fields[4])
-        } else {
-            let fields_ws: Vec<&str> = line.split_whitespace().collect();
-            if fields_ws.len() < 5 {
-                continue;
-            }
-            (
-                fields_ws[0],
-                fields_ws[1],
-                fields_ws[2],
-                fields_ws[3],
-                fields_ws[4],
-            )
-        };
+        let (taxid, rank, taxpath, taxpathsn, percentage, cami_genome_id, cami_otu, hosts) =
+            if fields.len() >= 5 {
+                let genome_id = fields.get(5).map(|v| v.trim()).filter(|v| !v.is_empty());
+                let otu = fields.get(6).map(|v| v.trim()).filter(|v| !v.is_empty());
+                let hosts = fields.get(7).map(|v| v.trim()).filter(|v| !v.is_empty());
+                (
+                    fields[0], fields[1], fields[2], fields[3], fields[4], genome_id, otu, hosts,
+                )
+            } else {
+                let fields_ws: Vec<&str> = line.split_whitespace().collect();
+                if fields_ws.len() < 5 {
+                    continue;
+                }
+                (
+                    fields_ws[0],
+                    fields_ws[1],
+                    fields_ws[2],
+                    fields_ws[3],
+                    fields_ws[4],
+                    fields_ws.get(5).map(|v| v.trim()).filter(|v| !v.is_empty()),
+                    fields_ws.get(6).map(|v| v.trim()).filter(|v| !v.is_empty()),
+                    fields_ws.get(7).map(|v| v.trim()).filter(|v| !v.is_empty()),
+                )
+            };
 
         if let Some(s) = current.as_mut() {
             let entry = Entry {
@@ -94,6 +167,9 @@ pub fn parse_cami_reader<R: BufRead>(reader: R) -> Result<Vec<Sample>> {
                 taxpath: taxpath.to_string(),
                 taxpathsn: taxpathsn.to_string(),
                 percentage: percentage.parse().unwrap_or(0.0),
+                cami_genome_id: cami_genome_id.map(|v| v.to_string()),
+                cami_otu: cami_otu.map(|v| v.to_string()),
+                hosts: hosts.map(|v| v.to_string()),
             };
             s.entries.push(entry);
         }
@@ -128,16 +204,43 @@ pub fn write_cami(samples: &[Sample], out: &mut dyn Write) -> Result<()> {
         if let Some(v) = &s.version {
             writeln!(out, "@Version:{}", v)?;
         }
-        if !s.ranks.is_empty() {
-            writeln!(out, "@Ranks:{}", s.ranks.join("|"))?;
+        let rank_tokens = s.header_rank_tokens();
+        if !rank_tokens.is_empty() {
+            writeln!(out, "@Ranks:{}", rank_tokens.join("|"))?;
         }
-        writeln!(out, "@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE")?;
-        for e in &s.entries {
+        let extended = s.is_modern_format()
+            || s.entries
+                .iter()
+                .any(|e| e.cami_genome_id.is_some() || e.cami_otu.is_some() || e.hosts.is_some());
+        if extended {
             writeln!(
                 out,
-                "{}\t{}\t{}\t{}\t{}",
-                e.taxid, e.rank, e.taxpath, e.taxpathsn, e.percentage
+                "@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE\t_CAMI_genomeID\t_CAMI_OTU\tHOSTS"
             )?;
+        } else {
+            writeln!(out, "@@TAXID\tRANK\tTAXPATH\tTAXPATHSN\tPERCENTAGE")?;
+        }
+        for e in &s.entries {
+            if extended {
+                writeln!(
+                    out,
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    e.taxid,
+                    e.rank,
+                    e.taxpath,
+                    e.taxpathsn,
+                    e.percentage,
+                    e.cami_genome_id.as_deref().unwrap_or(""),
+                    e.cami_otu.as_deref().unwrap_or(""),
+                    e.hosts.as_deref().unwrap_or("")
+                )?;
+            } else {
+                writeln!(
+                    out,
+                    "{}\t{}\t{}\t{}\t{}",
+                    e.taxid, e.rank, e.taxpath, e.taxpathsn, e.percentage
+                )?;
+            }
         }
     }
     Ok(())

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -1,0 +1,174 @@
+use crate::cami::{Entry, Sample, open_output, write_cami};
+use crate::processing::{fill_up_default, round_percentages};
+use crate::taxonomy::{Taxonomy, default_taxdump_dir, ensure_taxdump};
+use anyhow::{Context, Result, bail};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+pub struct ConvertConfig<'a> {
+    pub input: Option<&'a PathBuf>,
+    pub output: Option<&'a PathBuf>,
+    pub taxid_column: usize,
+    pub abundance_column: usize,
+    pub sample_id: &'a str,
+    pub dmp_dir: Option<&'a PathBuf>,
+}
+
+pub fn run(cfg: &ConvertConfig) -> Result<()> {
+    ensure_valid_indices(cfg)?;
+
+    let dir = cfg.dmp_dir.cloned().unwrap_or_else(default_taxdump_dir);
+    ensure_taxdump(&dir).with_context(|| format!("ensuring taxdump in {}", dir.display()))?;
+    let taxonomy = Taxonomy::load(&dir)?;
+
+    let modern = taxonomy.uses_modern_ranks();
+    let mut sample = Sample {
+        id: cfg.sample_id.to_string(),
+        version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        ranks: Vec::new(),
+        rank_groups: Vec::new(),
+        rank_aliases: HashMap::new(),
+        entries: Vec::new(),
+    };
+    let groups = if modern {
+        modern_rank_groups()
+    } else {
+        legacy_rank_groups()
+    };
+    sample.set_rank_groups(groups);
+
+    let records = read_records(cfg)?;
+    if records.is_empty() {
+        bail!("no data rows found in input TSV");
+    }
+
+    for (taxid_str, taxid_value, abundance) in records {
+        let mut rank = taxonomy
+            .rank_of(taxid_value)
+            .unwrap_or_else(|| "no rank".to_string());
+        if sample.rank_index(&rank).is_none() && rank.eq_ignore_ascii_case("no rank") {
+            if sample.rank_index("strain").is_some() {
+                rank = "strain".to_string();
+            }
+        }
+        if sample.rank_index(&rank).is_none() {
+            bail!(
+                "rank '{}' for taxid {} is not present in the @Ranks header",
+                rank,
+                taxid_str
+            );
+        }
+        sample.entries.push(Entry {
+            taxid: taxid_str,
+            rank,
+            taxpath: String::new(),
+            taxpathsn: String::new(),
+            percentage: abundance,
+            cami_genome_id: None,
+            cami_otu: None,
+            hosts: None,
+        });
+    }
+
+    let mut samples = vec![sample];
+    fill_up_default(&mut samples, None, &taxonomy);
+    round_percentages(&mut samples);
+
+    let mut out = open_output(cfg.output)?;
+    write_cami(&samples, &mut *out)?;
+    Ok(())
+}
+
+fn ensure_valid_indices(cfg: &ConvertConfig) -> Result<()> {
+    if cfg.taxid_column == 0 {
+        bail!("taxid column indices are 1-based; got 0");
+    }
+    if cfg.abundance_column == 0 {
+        bail!("abundance column indices are 1-based; got 0");
+    }
+    Ok(())
+}
+
+fn read_records(cfg: &ConvertConfig) -> Result<Vec<(String, u32, f64)>> {
+    let taxid_idx = cfg.taxid_column - 1;
+    let abundance_idx = cfg.abundance_column - 1;
+    let reader = open_reader(cfg.input)?;
+    let mut records = Vec::new();
+    let mut first = true;
+
+    for (line_no, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("reading line {}", line_no + 1))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut fields: Vec<&str> = line.split('\t').collect();
+        if fields.len() <= taxid_idx || fields.len() <= abundance_idx {
+            fields = line.split_whitespace().collect();
+        }
+        if fields.len() <= taxid_idx || fields.len() <= abundance_idx {
+            continue;
+        }
+        let taxid_raw = fields[taxid_idx].trim();
+        let abundance_raw = fields[abundance_idx].trim();
+        if first {
+            first = false;
+            if taxid_raw.parse::<u32>().is_err() || abundance_raw.parse::<f64>().is_err() {
+                continue;
+            }
+        }
+        let taxid_value: u32 = taxid_raw
+            .parse()
+            .with_context(|| format!("parsing taxid on line {}", line_no + 1))?;
+        let abundance: f64 = abundance_raw
+            .parse()
+            .with_context(|| format!("parsing abundance on line {}", line_no + 1))?;
+        records.push((taxid_raw.to_string(), taxid_value, abundance));
+    }
+
+    Ok(records)
+}
+
+fn open_reader(input: Option<&PathBuf>) -> Result<Box<dyn BufRead>> {
+    if let Some(path) = input {
+        if path != Path::new("-") {
+            let file = File::open(path)
+                .with_context(|| format!("opening input TSV {}", path.display()))?;
+            return Ok(Box::new(BufReader::new(file)));
+        }
+    }
+    Ok(Box::new(BufReader::new(io::stdin().lock())))
+}
+
+fn legacy_rank_groups() -> Vec<Vec<String>> {
+    vec![
+        vec!["superkingdom".to_string()],
+        vec!["phylum".to_string()],
+        vec!["class".to_string()],
+        vec!["order".to_string()],
+        vec!["family".to_string()],
+        vec!["genus".to_string()],
+        vec!["species".to_string()],
+        vec!["strain".to_string()],
+    ]
+}
+
+fn modern_rank_groups() -> Vec<Vec<String>> {
+    vec![
+        vec![
+            "cellular root".to_string(),
+            "acellular root".to_string(),
+            "other entries".to_string(),
+        ],
+        vec!["domain".to_string(), "realm".to_string()],
+        vec!["kingdom".to_string()],
+        vec!["phylum".to_string()],
+        vec!["class".to_string()],
+        vec!["order".to_string()],
+        vec!["family".to_string()],
+        vec!["genus".to_string()],
+        vec!["species".to_string()],
+        vec!["strain".to_string()],
+    ]
+}

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -14,21 +14,24 @@ pub fn run(cfg: &ListConfig) -> Result<()> {
 
     for sample in &samples {
         writeln!(out, "Sample: {}", sample.id)?;
-        writeln!(out, "  Ranks: {}", sample.ranks.join(", "))?;
+        let rank_tokens = sample.header_rank_tokens();
+        writeln!(out, "  Ranks: {}", rank_tokens.join(", "))?;
         writeln!(out, "  Total taxa: {}", sample.entries.len())?;
 
-        let mut stats: HashMap<&str, (usize, f64)> = HashMap::new();
+        let mut stats: HashMap<usize, (usize, f64)> = HashMap::new();
         for entry in &sample.entries {
-            let stat = stats.entry(&entry.rank).or_insert((0, 0.0));
-            if entry.percentage > 0.0 {
-                stat.0 += 1;
-                stat.1 += entry.percentage;
+            if let Some(idx) = sample.rank_index(&entry.rank) {
+                let stat = stats.entry(idx).or_insert((0, 0.0));
+                if entry.percentage > 0.0 {
+                    stat.0 += 1;
+                    stat.1 += entry.percentage;
+                }
             }
         }
 
-        for rank in &sample.ranks {
-            let (count, total) = stats.get(rank.as_str()).cloned().unwrap_or((0, 0.0));
-            writeln!(out, "    {}: taxa={} total={:.3}", rank, count, total)?;
+        for (idx, token) in rank_tokens.iter().enumerate() {
+            let (count, total) = stats.get(&idx).cloned().unwrap_or((0, 0.0));
+            writeln!(out, "    {}: taxa={} total={:.3}", token, count, total)?;
         }
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod benchmark;
+pub mod convert;
 pub mod fillup;
 pub mod filter;
 pub mod list;

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -2,7 +2,7 @@ use crate::cami::{Entry, load_samples, open_output, write_cami};
 use anyhow::Result;
 use clap::ValueEnum;
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[derive(Clone, Copy)]
@@ -39,27 +39,78 @@ pub fn run(cfg: &SortConfig) -> Result<()> {
 
     for sample in samples.iter_mut() {
         let entries = std::mem::take(&mut sample.entries);
-        let mut by_rank: HashMap<String, Vec<Entry>> = HashMap::new();
+        let mut by_rank: HashMap<usize, Vec<Entry>> = HashMap::new();
+        let mut unknown_order: Vec<String> = Vec::new();
+        let mut unknown_map: HashMap<String, Vec<Entry>> = HashMap::new();
         for entry in entries {
-            by_rank.entry(entry.rank.clone()).or_default().push(entry);
-        }
-
-        let mut ordered_ranks = Vec::new();
-        let mut seen: HashSet<String> = HashSet::new();
-        for rank in &sample.ranks {
-            if seen.insert(rank.clone()) {
-                ordered_ranks.push(rank.clone());
-            }
-        }
-        for rank in by_rank.keys() {
-            if seen.insert(rank.clone()) {
-                ordered_ranks.push(rank.clone());
+            if let Some(idx) = sample.rank_index(&entry.rank) {
+                by_rank.entry(idx).or_default().push(entry);
+            } else {
+                let key = entry.rank.clone();
+                if !unknown_map.contains_key(&key) {
+                    unknown_order.push(key.clone());
+                }
+                unknown_map.entry(key).or_default().push(entry);
             }
         }
 
         let mut new_entries = Vec::new();
-        for rank in ordered_ranks {
-            if let Some(mut entries) = by_rank.remove(&rank) {
+        for idx in 0..sample.ranks.len() {
+            if let Some(mut entries) = by_rank.remove(&idx) {
+                match cfg.mode {
+                    SortMode::Abundance => {
+                        entries.retain(|e| e.percentage > 0.0);
+                        entries.sort_by(|a, b| {
+                            match b
+                                .percentage
+                                .partial_cmp(&a.percentage)
+                                .unwrap_or(Ordering::Equal)
+                            {
+                                Ordering::Equal => a.taxid.cmp(&b.taxid),
+                                other => other,
+                            }
+                        });
+                    }
+                    SortMode::TaxPath(field) => {
+                        entries.sort_by(|a, b| {
+                            let key_a = field.key(a);
+                            let key_b = field.key(b);
+                            key_a.cmp(key_b).then_with(|| a.taxid.cmp(&b.taxid))
+                        });
+                    }
+                }
+                new_entries.extend(entries);
+            }
+        }
+        let mut remaining_known: Vec<(usize, Vec<Entry>)> = by_rank.into_iter().collect();
+        remaining_known.sort_by_key(|(idx, _)| *idx);
+        for (_idx, mut entries) in remaining_known {
+            match cfg.mode {
+                SortMode::Abundance => {
+                    entries.retain(|e| e.percentage > 0.0);
+                    entries.sort_by(|a, b| {
+                        match b
+                            .percentage
+                            .partial_cmp(&a.percentage)
+                            .unwrap_or(Ordering::Equal)
+                        {
+                            Ordering::Equal => a.taxid.cmp(&b.taxid),
+                            other => other,
+                        }
+                    });
+                }
+                SortMode::TaxPath(field) => {
+                    entries.sort_by(|a, b| {
+                        let key_a = field.key(a);
+                        let key_b = field.key(b);
+                        key_a.cmp(key_b).then_with(|| a.taxid.cmp(&b.taxid))
+                    });
+                }
+            }
+            new_entries.extend(entries);
+        }
+        for rank in unknown_order {
+            if let Some(mut entries) = unknown_map.remove(&rank) {
                 match cfg.mode {
                     SortMode::Abundance => {
                         entries.retain(|e| e.percentage > 0.0);

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -583,8 +583,10 @@ fn parse_rank_list(raw: &str) -> Vec<String> {
 pub fn validate_rank_selectors(expr: &Expr, samples: &[Sample]) -> Result<()> {
     let mut ranks = BTreeSet::new();
     for sample in samples {
-        for rank in &sample.ranks {
-            ranks.insert(rank.clone());
+        for group in &sample.rank_groups {
+            for rank in group {
+                ranks.insert(rank.clone());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add grouped rank parsing/writing and optional CAMI columns to handle the modern taxonomy format
- add a `convert` subcommand that reads TSV abundances, completes taxonomy lineages, and writes CAMI output
- allow overriding the taxdump directory for taxonomy-driven commands and bump the crate version to 0.7.0

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f95fcb5900832ab7c98a9666cb42f1