### PR TITLE
Add viral realm grouping and taxonomy metadata updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cami"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cami"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 
 [dependencies]

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -7,6 +7,9 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
+const LEGACY_CAMI_VERSION: &str = "0.10.0";
+const MODERN_CAMI_VERSION: &str = "0.11.0";
+
 pub struct ConvertConfig<'a> {
     pub input: Option<&'a PathBuf>,
     pub output: Option<&'a PathBuf>,
@@ -14,6 +17,7 @@ pub struct ConvertConfig<'a> {
     pub abundance_column: usize,
     pub sample_id: &'a str,
     pub dmp_dir: Option<&'a PathBuf>,
+    pub taxonomy_tag: Option<&'a str>,
 }
 
 pub fn run(cfg: &ConvertConfig) -> Result<()> {
@@ -24,9 +28,15 @@ pub fn run(cfg: &ConvertConfig) -> Result<()> {
     let taxonomy = Taxonomy::load(&dir)?;
 
     let modern = taxonomy.uses_modern_ranks();
+    let version = if modern {
+        MODERN_CAMI_VERSION
+    } else {
+        LEGACY_CAMI_VERSION
+    };
     let mut sample = Sample {
         id: cfg.sample_id.to_string(),
-        version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        version: Some(version.to_string()),
+        taxonomy_tag: cfg.taxonomy_tag.map(|tag| tag.to_string()),
         ranks: Vec::new(),
         rank_groups: Vec::new(),
         rank_aliases: HashMap::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,11 @@ enum Commands {
         )]
         by_domain: bool,
         #[arg(
+            long = "group-realms",
+            help = "Group viral realms under the Viruses superkingdom when scoring and filtering."
+        )]
+        group_realms: bool,
+        #[arg(
             short = 'o',
             long = "output",
             value_name = "DIR",
@@ -295,12 +300,20 @@ enum Commands {
         )]
         abundance_column: usize,
         #[arg(
+            short = 's',
             long = "sample-id",
             value_name = "ID",
             default_value = "sample",
             help = "Sample ID to use in the generated CAMI profile."
         )]
         sample_id: String,
+        #[arg(
+            short = 'T',
+            long = "taxonomy-tag",
+            value_name = "TAG",
+            help = "@TaxonomyID value describing the NCBI taxonomy snapshot (e.g. 2025-06-19)."
+        )]
+        taxonomy_tag: Option<String>,
         #[arg(
             long = "dmp-dir",
             value_name = "DIR",
@@ -352,6 +365,7 @@ fn main() -> Result<()> {
             pred_filter,
             normalize,
             by_domain,
+            group_realms,
             output,
             ranks,
             dmp_dir,
@@ -368,6 +382,7 @@ fn main() -> Result<()> {
                 pred_filter: pred_filter.clone(),
                 normalize: *normalize,
                 by_domain: *by_domain,
+                group_realms: *group_realms,
                 output: output.clone(),
                 ranks: rank_vec,
                 dmp_dir: dmp_dir.clone(),
@@ -438,6 +453,7 @@ fn main() -> Result<()> {
             taxid_column,
             abundance_column,
             sample_id,
+            taxonomy_tag,
             dmp_dir,
         } => {
             let cfg = ConvertRunConfig {
@@ -446,6 +462,7 @@ fn main() -> Result<()> {
                 taxid_column: *taxid_column,
                 abundance_column: *abundance_column,
                 sample_id,
+                taxonomy_tag: taxonomy_tag.as_deref(),
                 dmp_dir: dmp_dir.as_ref(),
             };
             convert_cmd::run(&cfg)


### PR DESCRIPTION
## Summary
- add a `--group-realms` switch to benchmark so viral realms are treated as the Viruses superkingdom during filtering and scoring
- persist taxonomy version tags in CAMI IO, expose realm lookups, and update convert to emit 0.11.0/0.10.0 headers with an optional @TaxonomyID tag (including a `-s` alias for sample IDs)
- bump the crate to 0.7.1 for the new taxonomy-aware behaviour

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f96ab9e3d0832abb716465bfeb535e