### PR TITLE
Handle merged taxids when filling CAMI profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cami"
-version = "0.7.2"
+version = "0.7.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cami"
-version = "0.7.2"
+version = "0.7.2.1"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ The generated CAMI table includes one sample populated with the modern or legacy
 
 ### cami fillup
 
-Populate missing higher ranks for every sample using the NCBI taxdump. Abundances retain their full precision after the hierarchy is filled.
+Populate missing higher ranks for every sample using the NCBI taxdump. Abundances retain their full precision after the hierarchy is filled, and the command adapts to either the legacy or modern CAMI rank sets present in your taxonomy snapshot.
 
 ```bash
-cami fillup --to-rank family examples/test.cami > with_family.cami
+cami fillup --to family examples/test.cami > with_family.cami
 ```
 
-If `--to-rank` is omitted, the command fills to the highest rank declared in each sample. Use `--from <rank>` to choose the source rank used for aggregation (defaults to `species` when available).
+If `--to` is omitted, the command fills to the highest rank declared in each sample. Use `--from <rank>` to choose the source rank used for aggregation (defaults to `species` when available). When an entry references a taxid that has been merged or deleted, `cami fillup` prints a warning to stderr but keeps processing the rest of the table.
 
 ### cami renorm
 
@@ -221,4 +221,4 @@ Remember that each command reads from stdin when no input path is supplied and w
 
 ### Taxonomy data cache
 
-Commands that require lineage information (`filter --fill-up`, `fillup`) download the NCBI taxdump once and cache it under `~/.cami`. Subsequent runs reuse the cached files. You can remove the directory to force a refresh.
+Commands that require lineage information (`filter --fill-up`, `fillup`, `convert`, `benchmark` with taxonomy updates, etc.) automatically download the NCBI taxdump the first time you run `cami` and cache the extracted files under `~/.cami`. Later runs reuse that directory as the default taxdump source. To refresh the taxonomy, download the latest taxdump from NCBI and replace the files in `~/.cami` (or remove the directory to trigger a fresh download). When cached taxonomy data indicates that a taxid has been merged or deleted, the affected commands emit warnings on stderr but continue producing complete output.

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,5 +1,5 @@
 use crate::cami::{Entry, Sample};
-use crate::taxonomy::{Taxonomy, parse_taxid};
+use crate::taxonomy::Taxonomy;
 use anyhow::{Result, anyhow, bail};
 use regex::Regex;
 use std::cmp::Ordering;
@@ -740,8 +740,8 @@ fn eval_tax(atom: &str, entry: &Entry, taxonomy: Option<&Taxonomy>) -> Option<bo
 }
 
 fn eval_taxonomy(entry: &Entry, taxonomy: &Taxonomy, op: &str, value: &str) -> bool {
-    let entry_taxid = parse_taxid(&entry.taxid);
-    let target_taxid = parse_taxid(value);
+    let entry_taxid = taxonomy.resolve_taxid_str(&entry.taxid);
+    let target_taxid = taxonomy.resolve_taxid_str(value);
 
     match op {
         "==" => match (entry_taxid, target_taxid) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,8 @@ enum Commands {
         )]
         from_rank: Option<String>,
         #[arg(
-            long,
+            long = "to",
+            alias = "to-rank",
             default_value = "phylum",
             help = "Highest rank to build during fill-up (inclusive)."
         )]
@@ -254,7 +255,8 @@ enum Commands {
         #[arg(short, long, help = "Write output to a file instead of stdout.")]
         output: Option<PathBuf>,
         #[arg(
-            long,
+            long = "to",
+            alias = "to-rank",
             help = "Highest rank to fill to (inclusive); defaults to the first declared rank."
         )]
         to_rank: Option<String>,

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -1,5 +1,5 @@
 use crate::cami::{Entry, Sample};
-use crate::taxonomy::{Taxonomy, parse_taxid};
+use crate::taxonomy::Taxonomy;
 use std::collections::{BTreeSet, HashMap};
 
 #[derive(Clone)]
@@ -264,7 +264,7 @@ where
 }
 
 fn build_rank_map(sample: &Sample, taxonomy: &Taxonomy, taxid: &str) -> Option<RankMap> {
-    let tid = parse_taxid(taxid)?;
+    let tid = taxonomy.resolve_taxid_str(taxid)?;
     let lineage = taxonomy.lineage(tid);
     let mut map: RankMap = HashMap::new();
     for (tid_u32, rank, name) in lineage.iter() {


### PR DESCRIPTION
## Summary
- load merged.dmp and delnodes.dmp when building the taxonomy cache and surface warnings for merged, deleted, or missing taxids
- resolve taxids across fillup, filter, and benchmark code paths, update the CLI to prefer --to, and document the behaviour in the README
- describe the taxonomy cache lifecycle in the README and bump the crate version to 0.7.2.1

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68fb8ffe18d8832a8ae44f0cc2ac5d76