### PR TITLE
Refine benchmark taxonomy normalization and document update flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cami"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cami"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ cami benchmark -g truth.cami predictions/profiler1.cami predictions/profiler2.ca
 - `--gf` filters the ground-truth profile before scoring using the same expression language as `cami filter`.
 - `--pf` applies an expression filter to every predicted profile before metrics are computed.
 - `-n, --normalize` rescales each sample/rank in every profile so positive abundances sum to 100 prior to computing metrics.
+- `--update-taxonomy` resolves every taxid through the NCBI merged and deleted node tables so profiles recorded against different taxonomy snapshots still align before scoring.
 - `--by-domain` produces additional TSV files restricted to Bacteria, Archaea, Eukarya, and Viruses alongside the overall report.
 - `-o, --output` points to the directory where reports such as `benchmark.tsv` and `benchmark_bacteria.tsv` are written.
 - `-r, --ranks` restricts the evaluation to specific ranks; mix short forms (`p,c,g`) and full names (`phylum,class,genus`).


### PR DESCRIPTION
## Summary
- reuse cached lineage data while updating benchmark entries so resolved taxids are applied without cloning
- document the `--update-taxonomy` option for `cami benchmark` and bump the crate version to 0.7.4

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68fba05a5d64832a8428415d3401b67c