### PR TITLE
Fix convert handling of unresolved taxids and strain entries

### DIFF
--- a/src/processing.rs
+++ b/src/processing.rs
@@ -207,11 +207,6 @@ fn select_base_rank(sample: &Sample, from_rank: Option<&str>) -> Option<usize> {
             }
         }
     }
-    if let Some(idx) = sample.rank_index("species") {
-        if has_entries_at(sample, idx) {
-            return Some(idx);
-        }
-    }
     sample
         .ranks
         .iter()


### PR DESCRIPTION
## Summary
- resolve taxids during `convert`, warning on missing entries and using merged identifiers for downstream processing
- choose the most specific available rank when filling taxonomy paths so strain-level rows are retained

## Testing
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941c85a4858832a870c785f1c71657f)