### PR TITLE
Fix convert aggregation and input scaling

### DIFF
--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -15,6 +15,8 @@ pub struct ConvertConfig<'a> {
     pub output: Option<&'a PathBuf>,
     pub taxid_column: usize,
     pub abundance_column: usize,
+    pub input_is_percent: bool,
+    pub normalize: bool,
     pub sample_id: &'a str,
     pub dmp_dir: Option<&'a PathBuf>,
     pub taxonomy_tag: Option<&'a str>,
@@ -54,9 +56,33 @@ pub fn run(cfg: &ConvertConfig) -> Result<()> {
         bail!("no data rows found in input TSV");
     }
 
+    let scale = if cfg.input_is_percent { 1.0 } else { 100.0 };
+    let total: f64 = records
+        .iter()
+        .map(|(_, _, abundance)| abundance * scale)
+        .sum();
+    let norm_factor = if cfg.normalize {
+        if total == 0.0 {
+            bail!("cannot normalize because total abundance is zero");
+        }
+        100.0 / total
+    } else {
+        1.0
+    };
+
     for (taxid_str, taxid_value, abundance) in records {
+        let resolved_taxid = match taxonomy.resolve_taxid(taxid_value) {
+            Some(value) => value,
+            None => {
+                eprintln!(
+                    "warning: skipping taxid {taxid_str} because it is not present in the taxonomy"
+                );
+                continue;
+            }
+        };
+
         let mut rank = taxonomy
-            .rank_of(taxid_value)
+            .rank_of(resolved_taxid)
             .unwrap_or_else(|| "no rank".to_string());
         if sample.rank_index(&rank).is_none() && rank.eq_ignore_ascii_case("no rank") {
             if sample.rank_index("strain").is_some() {
@@ -71,11 +97,11 @@ pub fn run(cfg: &ConvertConfig) -> Result<()> {
             );
         }
         sample.entries.push(Entry {
-            taxid: taxid_str,
+            taxid: resolved_taxid.to_string(),
             rank,
             taxpath: String::new(),
             taxpathsn: String::new(),
-            percentage: abundance,
+            percentage: abundance * scale * norm_factor,
             cami_genome_id: None,
             cami_otu: None,
             hosts: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,16 @@ enum Commands {
         )]
         abundance_column: usize,
         #[arg(
+            long = "input-percent",
+            help = "Treat abundances as percentages instead of fractions (0-1)."
+        )]
+        input_percent: bool,
+        #[arg(
+            long = "norm",
+            help = "Normalize abundances to total 100 before converting."
+        )]
+        normalize: bool,
+        #[arg(
             short = 's',
             long = "sample-id",
             value_name = "ID",
@@ -454,6 +464,8 @@ fn main() -> Result<()> {
             output,
             taxid_column,
             abundance_column,
+            input_percent,
+            normalize,
             sample_id,
             taxonomy_tag,
             dmp_dir,
@@ -463,6 +475,8 @@ fn main() -> Result<()> {
                 output: output.as_ref(),
                 taxid_column: *taxid_column,
                 abundance_column: *abundance_column,
+                input_is_percent: *input_percent,
+                normalize: *normalize,
                 sample_id,
                 taxonomy_tag: taxonomy_tag.as_deref(),
                 dmp_dir: dmp_dir.as_ref(),

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -92,7 +92,7 @@ pub fn fill_up_to(
             let Some(entry_rank_idx) = sample.rank_index(&entry.rank) else {
                 continue;
             };
-            if entry_rank_idx != base_idx {
+            if entry_rank_idx < start_idx || entry_rank_idx > base_idx {
                 continue;
             }
             let fallback_entry = existing_by_key.get(&(entry_rank_idx, entry.taxid.clone()));
@@ -103,13 +103,10 @@ pub fn fill_up_to(
             };
 
             for rank_idx in start_idx..=end_idx {
-                if rank_idx == entry_rank_idx {
+                if rank_idx == entry_rank_idx || rank_idx > entry_rank_idx {
                     continue;
                 }
                 if let Some(detail) = rank_map.get(&rank_idx) {
-                    if existing_by_key.contains_key(&(rank_idx, detail.taxid.clone())) {
-                        continue;
-                    }
                     *sums.entry((rank_idx, detail.taxid.clone())).or_insert(0.0) +=
                         entry.percentage;
                 }
@@ -135,9 +132,8 @@ pub fn fill_up_to(
 
             for taxid in taxids {
                 let existing_entry = existing_by_key.get(&(idx, taxid.clone()));
-                let percentage = existing_entry
-                    .map(|e| e.percentage)
-                    .unwrap_or_else(|| *sums.get(&(idx, taxid.clone())).unwrap_or(&0.0));
+                let percentage = sums.get(&(idx, taxid.clone())).cloned().unwrap_or(0.0)
+                    + existing_entry.map(|e| e.percentage).unwrap_or(0.0);
                 if percentage <= 0.0 {
                     continue;
                 }
@@ -207,11 +203,6 @@ fn select_base_rank(sample: &Sample, from_rank: Option<&str>) -> Option<usize> {
             }
         }
     }
-    if let Some(idx) = sample.rank_index("species") {
-        if has_entries_at(sample, idx) {
-            return Some(idx);
-        }
-    }
     sample
         .ranks
         .iter()
@@ -269,7 +260,10 @@ fn build_rank_map(sample: &Sample, taxonomy: &Taxonomy, taxid: &str) -> Option<R
     let mut map: RankMap = HashMap::new();
     for (tid_u32, rank, name) in lineage.iter() {
         let mut effective_rank = rank.clone();
-        if sample.rank_index(&effective_rank).is_none() && rank.eq_ignore_ascii_case("no rank") {
+        if rank.eq_ignore_ascii_case("no rank") {
+            if *tid_u32 != tid {
+                continue;
+            }
             if sample.rank_index("strain").is_some() {
                 effective_rank = "strain".to_string();
             }


### PR DESCRIPTION
## Summary
- include descendant abundances even when the ancestor already exists so species totals capture strain contributions
- add convert flags to specify whether input abundances are fractions or percents and optionally normalize to 100 before conversion
- scale convert output to percentages consistently before filling taxonomy paths

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941c85a4858832a870c785f1c71657f)