### PR TITLE
Simplify benchmark realm-grouping CLI by keeping only opt-out flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "camitk"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ camitk benchmark -g truth.cami predictions/profiler1.cami predictions/profiler2.
 - `--update-taxonomy` resolves every taxid through the NCBI merged and deleted node tables so profiles recorded against different taxonomy snapshots still align before scoring.
 - `--by-domain` produces additional TSV files restricted to Bacteria, Archaea, Eukarya, and Viruses alongside the overall report.
 - `--detail` (alias `--verbose`) also writes per-taxon TP/FP/FN tables (`benchmark_details*.tsv`) with both predicted and ground-truth abundances when available.
-- `--group-realms` groups viral realms under Viruses during scoring/filtering (enabled by default).
+- Viral realms are grouped under Viruses during scoring/filtering by default.
 - `--no-group-realms` disables viral realm grouping when you need strict lineage handling without realm folding.
 - `-o, --output` points to the directory where reports such as `benchmark.tsv` and `benchmark_bacteria.tsv` are written.
 - `-r, --ranks` restricts the evaluation to specific ranks; mix short forms (`p,c,g`) and full names (`phylum,class,genus`).

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,16 +121,8 @@ enum Commands {
         )]
         detail: bool,
         #[arg(
-            long = "group-realms",
-            action = clap::ArgAction::SetTrue,
-            default_value_t = true,
-            help = "Group viral realms under the Viruses superkingdom when scoring and filtering (default: enabled)."
-        )]
-        group_realms: bool,
-        #[arg(
             long = "no-group-realms",
             action = clap::ArgAction::SetTrue,
-            conflicts_with = "group_realms",
             help = "Disable viral realm grouping so realms are not folded into Viruses."
         )]
         no_group_realms: bool,
@@ -393,7 +385,6 @@ fn main() -> Result<()> {
             normalize,
             by_domain,
             detail,
-            group_realms,
             no_group_realms,
             output,
             ranks,
@@ -412,7 +403,7 @@ fn main() -> Result<()> {
                 normalize: *normalize,
                 by_domain: *by_domain,
                 detail: *detail,
-                group_realms: *group_realms && !*no_group_realms,
+                group_realms: !*no_group_realms,
                 output: output.clone(),
                 ranks: rank_vec,
                 dmp_dir: dmp_dir.clone(),


### PR DESCRIPTION
### Motivation
- The `--group-realms` flag was redundant because viral-realm grouping is the default behavior, and `--no-group-realms` is sufficient to opt out. 
- Removing the no-op enable flag reduces CLI surface and avoids user confusion about default semantics.

### Description
- Removed the explicit `--group-realms` CLI argument from the benchmark command in `src/main.rs` and kept only `--no-group-realms` as the opt-out switch. 
- Made the benchmark configuration compute `group_realms` as `!*no_group_realms` so grouping remains the default. 
- Updated `README.md` to state that viral realms are grouped under Viruses by default and to keep only the `--no-group-realms` note. 
- Refreshed the lockfile (`Cargo.lock`) to the current package version metadata.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -q` which executed 25 tests and reported `ok` (25 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54b952868832a928b9729616981e1)