### PR TITLE
Strict CAMI parsing, rank canonicalization, aggregation/normalization fixes, and tests

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,136 @@
+# Comprehensive code review
+
+This review covers the shared CAMI parser/writer, taxonomy loader, expression engine,
+processing primitives, and every CLI subcommand in `src/commands`. It distinguishes
+correctness defects fixed during the review from lower-risk design and performance
+follow-ups that should be addressed separately.
+
+## Correctness fixes made during this review
+
+| Area | Finding | Resolution |
+| --- | --- | --- |
+| All CAMI-reading commands | Malformed percentages were silently converted to `0`, truncated rows were silently skipped, and data before `@SampleID` was ignored. This could silently change profiles and every downstream result. | Parsing now returns a line-numbered error for malformed, non-finite, or negative percentages, truncated rows, and rows before a sample header. |
+| `preview` | `@TaxonomyID` was dropped, so preview output did not preserve all sample metadata. | Preserve the taxonomy tag in preview output. |
+| `fillup` and `filter --fill-up` | Filling a bounded rank interval replaced the entire entry list and discarded valid entries above and below that interval. | Preserve entries outside the requested interval while rebuilding entries inside it. |
+| `benchmark --ranks` | Requested canonical ranks were compared with raw input rank names. For example, selecting `superkingdom` excluded entries whose equivalent CAMI rank was named `domain`. | Canonicalize the entry rank before applying the rank filter. |
+| `benchmark` metrics | Duplicate rows for one taxid were overwritten in metric maps, while totals and detail output included every duplicate. Detection, distance, correlation, and abundance-rank results could therefore disagree with one another. | Aggregate duplicate taxids consistently before metric calculation. |
+| `convert --norm` | Unknown/deleted/unmappable rows remained in the normalization denominator, allowing normalized output below 100%. | Normalize only successfully mapped rows. |
+| `convert` | Negative and non-finite inputs were accepted, duplicate resolution warnings were printed, and completely unmappable input emitted an empty profile. | Validate abundances, retain the taxonomy resolver's precise warning, and reject empty mapped output. |
+
+## Subcommand-by-subcommand assessment
+
+### `list`
+
+The implementation is linear in the number of entries and groups statistics by the
+declared rank index. It intentionally counts only positive-abundance taxa in per-rank
+statistics, while `Total taxa` reports physical rows. This difference is documented by
+the output labels but may surprise users; a future interface could report both row and
+positive-taxon counts explicitly.
+
+### `preview`
+
+The command preserves version, ranks, taxonomy tag, modern extended columns, and the
+first requested rows. It currently means "first N rows per sample," not "first N rows
+per rank". That behavior matches the implementation and should remain explicit in help
+text.
+
+### `filter`
+
+Boolean precedence (`&` before `|`), rank aliases, sample selectors, abundance filters,
+taxonomy ancestry filters, and per-rank cumulative sums were reviewed. Cumulative sums
+are calculated from least abundant to most abundant, matching the documented low-mass
+filter behavior. Two follow-ups remain:
+
+1. Numeric selector parsing currently falls back to zero for malformed values, so a
+   typo such as `a>abc` behaves like `a>0` instead of producing an error.
+2. Invalid regular expressions evaluate to false rather than returning a diagnostic.
+
+Fixing these cleanly requires making expression evaluation fallible and propagating
+errors through `apply_filter`; that API change should be isolated in a follow-up.
+
+### `fillup`
+
+Taxonomy lineage lookup is cached per taxid during each sample fill. Mixed-rank input
+adds descendant mass to directly assigned ancestor mass, which produces 90% at species
+and 100% at genus for the documented 90% species plus 10% genus-only example. Entries
+outside a bounded fill interval are now preserved.
+
+There is an inherent ambiguity when an input already contains a fully aggregated
+ancestor and all of its descendants: the file format does not indicate whether the
+ancestor value is direct-only mass or an existing aggregate. The current additive
+behavior is correct for mixed-rank direct assignments but can double-count a profile
+whose ancestor rows are already aggregate totals. A future interface should expose an
+explicit `direct` versus `already-aggregated` policy rather than guessing.
+
+### `renorm`
+
+Positive values are independently rescaled to 100 within each sample/rank. Zero values
+remain zero. The stricter shared parser now prevents negative and non-finite values from
+reaching this operation. Floating-point rounding can still leave a displayed sum a few
+units in the final decimal place away from exactly 100; this is normal unless an exact
+sum-correction policy is added.
+
+### `sort`
+
+Abundance sorting is descending with taxid as a deterministic tie-breaker and drops
+zero-abundance rows as documented. Taxonomy-path sorting preserves zeroes. The same
+sorting block is repeated for known, remaining, and unknown rank groups; extracting a
+single helper would reduce maintenance risk but does not materially change runtime.
+
+### `convert`
+
+The selected taxdump supplies current taxids, ranks, lineage taxids, and scientific
+names. Merged identifiers are resolved transitively. Deleted and unknown identifiers
+are omitted with warnings. Conversion and mixed-rank behavior now have fixture-backed
+tests covering current identifiers/names, normalization, and invalid abundance input.
+
+### `benchmark`
+
+The following metric implementations were checked:
+
+- Detection metrics use taxid presence at positive abundance: TP, FP, FN, precision,
+  recall, F1, and Jaccard follow their standard set formulas.
+- L1 and Bray-Curtis compare per-profile relative abundance over the union of observed
+  taxids. With normalized compositions, Bray-Curtis is one half of L1.
+- Shannon diversity uses natural logarithms and ignores zero mass. Pielou-style
+  evenness divides Shannon diversity by the log of the number of positive taxa and is
+  undefined for fewer than two positive taxa.
+- Pearson uses relative abundance over the union of taxa. Spearman converts values to
+  average ranks for ties and then applies Pearson correlation to those ranks.
+- Weighted and unweighted UniFrac use unit-length canonical taxonomic edges. Each
+  profile is normalized to unit mass before weighted edge-flow differences are
+  calculated. Unweighted UniFrac divides unique branch length by union branch length.
+  The weighted score is divided by twice the root-to-evaluation-rank path length, as
+  documented by this project; this is a project-specific normalization rather than a
+  claim of equivalence to every external UniFrac implementation.
+- ARE is the project's rank-displacement score with explicit penalties for missed and
+  extra taxa. mARE weights normalized rank displacement by abundance and assigns full
+  penalty to taxa present in only one profile. Both are bounded to `[0, 1]`.
+
+Duplicate taxids are now aggregated consistently, and canonical rank aliases are
+filtered correctly. Remaining benchmark follow-ups are primarily scalability and
+definition clarity:
+
+1. With `--by-domain`, every prediction file is parsed, taxonomy-updated, and filtered
+   once per domain report. Preprocessing each prediction once before the domain loop
+   would substantially reduce work on large inputs.
+2. The lineage cache is rebuilt for each profile-map construction. A cache shared across
+   domain reports could reduce repeated lineage construction.
+3. Prediction-only sample IDs and ranks are not reported because iteration is driven by
+   ground-truth samples and ranks. This is defensible for a fixed benchmark design but
+   should be explicitly documented; users expecting those rows to count as false
+   positives may otherwise misinterpret results.
+4. ARE and mARE are project-specific metrics. Their formulas should eventually be
+   documented with equations and tie-policy examples, not only prose and unit tests.
+
+## Shared taxonomy and I/O assessment
+
+Taxdump parsing is parallelized across nodes, names, merged ids, and deleted ids.
+Lineages and ancestry queries are cached. Potential follow-ups include checking HTTP
+status before unpacking a downloaded taxdump, validating malformed dump rows instead of
+coercing invalid node ids to zero, and avoiding synchronization-backed caches when a
+taxonomy is used strictly from one thread.
+
+The CAMI writer preserves optional modern columns and emits grouped rank aliases. The
+reader is now deliberately strict for data integrity; callers receive contextual errors
+instead of silently altered profiles.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Turn a simple TSV of taxonomic abundances into a fully fledged CAMI profile. The
 
 If the first line of the TSV contains headers, the command automatically skips it as long as the taxid and abundance fields cannot be parsed as numbers. Abundance values are written to the CAMI file exactly as provided, so ensure your TSV reports percentages (multiply fractions by 100 before converting).
 
+Input rows may belong to different taxonomic ranks. During lineage filling, abundance assigned at a more specific rank is propagated to its ancestors, while abundance assigned only to an ancestor is not copied down to more specific ranks. For example, if species rows total 90% and genus-only rows total 10%, the converted profile totals 90% at species and 100% at genus (the 90% propagated from species plus the 10% assigned directly to genus). Thus a rank does not have to total 100%; `--norm` normalizes all successfully mapped input rows as a whole, not every output rank independently. Use `camitk renorm` only when each rank should be rescaled separately to 100%.
+
+Taxids, ranks, lineage taxids, and scientific names in the output come from the selected dump directory. If an input taxid appears in `merged.dmp`, `convert` writes its current replacement taxid and name and prints a warning. Deleted, unknown, and otherwise unmappable taxids are warned about and omitted; when `--norm` is used, normalization is calculated after those rows have been omitted.
+
 Key options:
 
 - `-i, --taxid-column <INDEX>` – 1-based column holding NCBI taxids. Defaults to `1`. Use this when the taxid column is not the first field (e.g., `-i 3` to read from the third column).

--- a/src/cami.rs
+++ b/src/cami.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Write};
@@ -102,8 +102,9 @@ pub fn parse_cami_reader<R: BufRead>(reader: R) -> Result<Vec<Sample>> {
     let mut samples = Vec::new();
     let mut current: Option<Sample> = None;
 
-    for line in reader.lines() {
-        let line = line?;
+    for (line_index, line) in reader.lines().enumerate() {
+        let line_number = line_index + 1;
+        let line = line.with_context(|| format!("reading CAMI line {line_number}"))?;
         let line = line.trim_end();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -159,7 +160,7 @@ pub fn parse_cami_reader<R: BufRead>(reader: R) -> Result<Vec<Sample>> {
             } else {
                 let fields_ws: Vec<&str> = line.split_whitespace().collect();
                 if fields_ws.len() < 5 {
-                    continue;
+                    bail!("CAMI data row on line {line_number} has fewer than 5 columns");
                 }
                 (
                     fields_ws[0],
@@ -174,17 +175,25 @@ pub fn parse_cami_reader<R: BufRead>(reader: R) -> Result<Vec<Sample>> {
             };
 
         if let Some(s) = current.as_mut() {
+            let percentage = percentage
+                .parse::<f64>()
+                .with_context(|| format!("parsing PERCENTAGE on CAMI line {line_number}"))?;
+            if !percentage.is_finite() || percentage < 0.0 {
+                bail!("PERCENTAGE on CAMI line {line_number} must be finite and non-negative");
+            }
             let entry = Entry {
                 taxid: taxid.to_string(),
                 rank: rank.to_string(),
                 taxpath: taxpath.to_string(),
                 taxpathsn: taxpathsn.to_string(),
-                percentage: percentage.parse().unwrap_or(0.0),
+                percentage,
                 cami_genome_id: cami_genome_id.map(|v| v.to_string()),
                 cami_otu: cami_otu.map(|v| v.to_string()),
                 hosts: hosts.map(|v| v.to_string()),
             };
             s.entries.push(entry);
+        } else {
+            bail!("CAMI data row on line {line_number} appears before @SampleID");
         }
     }
 
@@ -268,4 +277,25 @@ pub fn open_output(path: Option<&PathBuf>) -> Result<Box<dyn Write>> {
         _ => Box::new(io::stdout()),
     };
     Ok(writer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_cami_reader;
+    use std::io::Cursor;
+
+    #[test]
+    fn parser_rejects_invalid_percentages_instead_of_turning_them_into_zero() {
+        for percentage in ["not-a-number", "NaN", "inf", "-1"] {
+            let input =
+                format!("@SampleID:test\n@Ranks:species\n1\tspecies\t1\tname\t{percentage}\n");
+            assert!(parse_cami_reader(Cursor::new(input)).is_err());
+        }
+    }
+
+    #[test]
+    fn parser_reports_truncated_rows_and_rows_before_a_sample() {
+        assert!(parse_cami_reader(Cursor::new("@SampleID:test\n1\tspecies\n")).is_err());
+        assert!(parse_cami_reader(Cursor::new("1\tspecies\t1\tname\t10\n")).is_err());
+    }
 }

--- a/src/commands/benchmark.rs
+++ b/src/commands/benchmark.rs
@@ -307,8 +307,9 @@ fn build_profile_map(
             if entry.percentage <= 0.0 {
                 continue;
             }
+            let rank_name = canonical_rank(&entry.rank).unwrap_or_else(|_| entry.rank.clone());
             if let Some(filter) = &rank_filter {
-                if !filter.contains(&entry.rank) {
+                if !filter.contains(&rank_name) {
                     continue;
                 }
             }
@@ -317,7 +318,6 @@ fn build_profile_map(
                     continue;
                 }
             }
-            let rank_name = canonical_rank(&entry.rank).unwrap_or_else(|_| entry.rank.clone());
             let cache_key = lineage_cache_key(entry, &rank_name);
             let lineage = lineage_cache
                 .entry(cache_key)
@@ -581,7 +581,7 @@ fn compute_metrics(
             entry.taxid
         );
         if entry.percentage > 0.0 {
-            gt_map.insert(entry.taxid.clone(), entry.percentage);
+            *gt_map.entry(entry.taxid.clone()).or_insert(0.0) += entry.percentage;
         }
     }
     let mut pred_map: HashMap<String, f64> = HashMap::new();
@@ -597,7 +597,7 @@ fn compute_metrics(
             entry.taxid
         );
         if entry.percentage > 0.0 {
-            pred_map.insert(entry.taxid.clone(), entry.percentage);
+            *pred_map.entry(entry.taxid.clone()).or_insert(0.0) += entry.percentage;
         }
     }
 
@@ -1839,10 +1839,10 @@ fn format_float(value: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        CANONICAL_RANKS, LineageInfo, ProfileEntry, abundance_rank_error, canonical_rank_index,
-        compute_lineage, ensure_superkingdom_only, entry_belongs_to_domain,
-        entry_missing_superkingdom, highest_taxid_in_taxpath, mass_weighted_abundance_rank_error,
-        samples_need_superkingdom, unifrac, unifrac_components,
+        CANONICAL_RANKS, LineageInfo, ProfileEntry, abundance_rank_error, build_profile_map,
+        canonical_rank_index, compute_lineage, compute_metrics, ensure_superkingdom_only,
+        entry_belongs_to_domain, entry_missing_superkingdom, highest_taxid_in_taxpath,
+        mass_weighted_abundance_rank_error, samples_need_superkingdom, unifrac, unifrac_components,
     };
     use crate::cami::{Entry, Sample};
     use crate::taxonomy::Taxonomy;
@@ -1984,6 +1984,53 @@ mod tests {
             percentage,
             lineage,
         }
+    }
+
+    #[test]
+    fn metrics_sum_duplicate_taxids_consistently() {
+        let gt = vec![
+            profile_entry_for_test("2|10", 25.0),
+            profile_entry_for_test("2|10", 25.0),
+        ];
+        let pred = vec![profile_entry_for_test("2|10", 50.0)];
+
+        let metrics = compute_metrics("phylum", &gt, &pred).unwrap();
+        assert_eq!((metrics.tp, metrics.fp, metrics.fn_), (1, 0, 0));
+        assert!((metrics.l1_error - 0.0).abs() < 1e-12);
+        assert_eq!(metrics.abundance_rank_error, Some(0.0));
+    }
+
+    #[test]
+    fn rank_filter_matches_canonical_rank_aliases() {
+        let mut sample = Sample {
+            id: "sample".to_string(),
+            version: None,
+            taxonomy_tag: None,
+            ranks: Vec::new(),
+            rank_groups: Vec::new(),
+            rank_aliases: HashMap::new(),
+            entries: vec![Entry {
+                taxid: "2".to_string(),
+                rank: "domain".to_string(),
+                taxpath: "2".to_string(),
+                taxpathsn: "Bacteria".to_string(),
+                percentage: 100.0,
+                cami_genome_id: None,
+                cami_otu: None,
+                hosts: None,
+            }],
+        };
+        sample.set_rank_groups(vec![vec!["domain".to_string()]]);
+
+        let profiles = build_profile_map(
+            &[sample],
+            Some(&vec!["superkingdom".to_string()]),
+            false,
+            None,
+            None,
+            false,
+        );
+        assert_eq!(profiles["sample"]["superkingdom"].len(), 1);
     }
 
     #[test]

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -57,29 +57,11 @@ pub fn run(cfg: &ConvertConfig) -> Result<()> {
     }
 
     let scale = if cfg.input_is_percent { 1.0 } else { 100.0 };
-    let total: f64 = records
-        .iter()
-        .map(|(_, _, abundance)| abundance * scale)
-        .sum();
-    let norm_factor = if cfg.normalize {
-        if total == 0.0 {
-            bail!("cannot normalize because total abundance is zero");
-        }
-        100.0 / total
-    } else {
-        1.0
-    };
-
     let mut aggregated: HashMap<(String, String), f64> = HashMap::new();
     for (taxid_str, taxid_value, abundance) in records {
         let resolved_taxid = match taxonomy.resolve_taxid(taxid_value) {
             Some(value) => value,
-            None => {
-                eprintln!(
-                    "warning: skipping taxid {taxid_str} because it is not present in the taxonomy"
-                );
-                continue;
-            }
+            None => continue,
         };
 
         let mut rank = taxonomy
@@ -99,11 +81,26 @@ pub fn run(cfg: &ConvertConfig) -> Result<()> {
             continue;
         };
 
-        let percentage = abundance * scale * norm_factor;
+        let percentage = abundance * scale;
         aggregated
             .entry((target_taxid, target_rank))
             .and_modify(|value| *value += percentage)
             .or_insert(percentage);
+    }
+
+    if aggregated.is_empty() {
+        bail!("none of the input taxids could be mapped to a CAMI rank");
+    }
+
+    if cfg.normalize {
+        let retained_total: f64 = aggregated.values().sum();
+        if retained_total == 0.0 {
+            bail!("cannot normalize because the mapped abundance total is zero");
+        }
+        let norm_factor = 100.0 / retained_total;
+        for percentage in aggregated.values_mut() {
+            *percentage *= norm_factor;
+        }
     }
 
     let mut aggregated_entries: Vec<_> = aggregated.into_iter().collect();
@@ -173,6 +170,12 @@ fn read_records(cfg: &ConvertConfig) -> Result<Vec<(String, u32, f64)>> {
         let abundance: f64 = abundance_raw
             .parse()
             .with_context(|| format!("parsing abundance on line {}", line_no + 1))?;
+        if !abundance.is_finite() {
+            bail!("abundance on line {} must be finite", line_no + 1);
+        }
+        if abundance < 0.0 {
+            bail!("abundance on line {} cannot be negative", line_no + 1);
+        }
         records.push((taxid_raw.to_string(), taxid_value, abundance));
     }
 
@@ -246,4 +249,128 @@ fn modern_rank_groups() -> Vec<Vec<String>> {
         vec!["species".to_string()],
         vec!["strain".to_string()],
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cami::parse_cami;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct Fixture {
+        dir: PathBuf,
+        input: PathBuf,
+        output: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(input: &str) -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let dir = std::env::temp_dir().join(format!("camitk-convert-{nonce}"));
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(
+                dir.join("nodes.dmp"),
+                concat!(
+                    "1\t|\t1\t|\tno rank\t|\n",
+                    "2\t|\t1\t|\tsuperkingdom\t|\n",
+                    "10\t|\t2\t|\tgenus\t|\n",
+                    "11\t|\t10\t|\tspecies\t|\n",
+                    "20\t|\t2\t|\tgenus\t|\n",
+                ),
+            )
+            .unwrap();
+            fs::write(
+                dir.join("names.dmp"),
+                concat!(
+                    "1\t|\troot\t|\t\t|\tscientific name\t|\n",
+                    "2\t|\tBacteria\t|\t\t|\tscientific name\t|\n",
+                    "10\t|\tCurrent genus\t|\t\t|\tscientific name\t|\n",
+                    "11\t|\tCurrent species\t|\t\t|\tscientific name\t|\n",
+                    "20\t|\tGenus only\t|\t\t|\tscientific name\t|\n",
+                ),
+            )
+            .unwrap();
+            fs::write(dir.join("merged.dmp"), "99\t|\t11\t|\n").unwrap();
+            fs::write(dir.join("delnodes.dmp"), "").unwrap();
+            let input_path = dir.join("input.tsv");
+            let output = dir.join("output.cami");
+            fs::write(&input_path, input).unwrap();
+            Self {
+                dir,
+                input: input_path,
+                output,
+            }
+        }
+
+        fn run(&self, normalize: bool) -> Result<Sample> {
+            run(&ConvertConfig {
+                input: Some(&self.input),
+                output: Some(&self.output),
+                taxid_column: 1,
+                abundance_column: 2,
+                input_is_percent: true,
+                normalize,
+                sample_id: "test",
+                dmp_dir: Some(&self.dir),
+                taxonomy_tag: None,
+            })?;
+            Ok(parse_cami(&self.output)?.remove(0))
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn rank_total(sample: &Sample, rank: &str) -> f64 {
+        sample
+            .entries
+            .iter()
+            .filter(|entry| entry.rank == rank)
+            .map(|entry| entry.percentage)
+            .sum()
+    }
+
+    #[test]
+    fn mixed_ranks_use_current_dump_ids_names_and_expected_totals() {
+        let fixture = Fixture::new("taxid\tabundance\n99\t90\n20\t10\n");
+        let sample = fixture.run(false).unwrap();
+
+        assert_eq!(rank_total(&sample, "species"), 90.0);
+        assert_eq!(rank_total(&sample, "genus"), 100.0);
+        let species = sample
+            .entries
+            .iter()
+            .find(|entry| entry.rank == "species")
+            .unwrap();
+        assert_eq!(species.taxid, "11");
+        assert!(species.taxpathsn.ends_with("Current genus|Current species"));
+    }
+
+    #[test]
+    fn normalization_excludes_taxids_that_cannot_be_mapped() {
+        let fixture = Fixture::new("11\t50\n777\t50\n");
+        let sample = fixture.run(true).unwrap();
+
+        assert_eq!(rank_total(&sample, "species"), 100.0);
+        assert_eq!(rank_total(&sample, "genus"), 100.0);
+    }
+
+    #[test]
+    fn rejects_non_finite_and_negative_abundances() {
+        for abundance in ["NaN", "inf", "-1"] {
+            let fixture = Fixture::new(&format!("11\t{abundance}\n"));
+            let error = fixture.run(false).unwrap_err().to_string();
+            assert!(
+                error.contains("must be finite") || error.contains("cannot be negative"),
+                "unexpected error: {error}"
+            );
+        }
+    }
 }

--- a/src/commands/preview.rs
+++ b/src/commands/preview.rs
@@ -20,6 +20,9 @@ pub fn run(cfg: &PreviewConfig) -> Result<()> {
         if !rank_tokens.is_empty() {
             writeln!(out, "@Ranks:{}", rank_tokens.join("|"))?;
         }
+        if let Some(taxonomy_tag) = &sample.taxonomy_tag {
+            writeln!(out, "@TaxonomyID:{}", taxonomy_tag)?;
+        }
         let extended = sample.is_modern_format()
             || sample
                 .entries

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -113,7 +113,16 @@ pub fn fill_up_to(
             }
         }
 
-        let mut new_entries: Vec<Entry> = Vec::new();
+        let mut new_entries: Vec<Entry> = sample
+            .entries
+            .iter()
+            .filter(|entry| {
+                sample
+                    .rank_index(&entry.rank)
+                    .is_none_or(|idx| idx < start_idx || idx > end_idx)
+            })
+            .cloned()
+            .collect();
         for idx in 0..sample.ranks.len() {
             if idx < start_idx || idx > end_idx {
                 continue;
@@ -340,6 +349,8 @@ fn build_paths(sample: &Sample, rank_map: &RankMap, upto_idx: usize) -> (String,
 mod tests {
     use super::*;
     use crate::cami::Sample;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn build_paths_includes_placeholders_for_missing_ranks() {
@@ -388,5 +399,82 @@ mod tests {
 
         assert_eq!(taxpath, "131567|2759||5794");
         assert_eq!(taxpathsn, "cellular organisms|Eukaryota||Apicomplexa");
+    }
+
+    #[test]
+    fn fill_up_preserves_entries_outside_requested_rank_range() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("camitk-fillup-{nonce}"));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("nodes.dmp"),
+            concat!(
+                "1\t|\t1\t|\tno rank\t|\n",
+                "2\t|\t1\t|\tsuperkingdom\t|\n",
+                "10\t|\t2\t|\tgenus\t|\n",
+                "11\t|\t10\t|\tspecies\t|\n",
+                "12\t|\t11\t|\tno rank\t|\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            dir.join("names.dmp"),
+            concat!(
+                "1\t|\troot\t|\t\t|\tscientific name\t|\n",
+                "2\t|\tBacteria\t|\t\t|\tscientific name\t|\n",
+                "10\t|\tGenus\t|\t\t|\tscientific name\t|\n",
+                "11\t|\tSpecies\t|\t\t|\tscientific name\t|\n",
+                "12\t|\tStrain\t|\t\t|\tscientific name\t|\n",
+            ),
+        )
+        .unwrap();
+        let taxonomy = Taxonomy::load(&dir).unwrap();
+        let mut sample = Sample {
+            id: "sample".to_string(),
+            version: None,
+            taxonomy_tag: None,
+            ranks: Vec::new(),
+            rank_groups: Vec::new(),
+            rank_aliases: HashMap::new(),
+            entries: Vec::new(),
+        };
+        sample.set_rank_groups(vec![
+            vec!["superkingdom".to_string()],
+            vec!["genus".to_string()],
+            vec!["species".to_string()],
+            vec!["strain".to_string()],
+        ]);
+        for (taxid, rank) in [("2", "superkingdom"), ("11", "species"), ("12", "strain")] {
+            sample.entries.push(Entry {
+                taxid: taxid.to_string(),
+                rank: rank.to_string(),
+                taxpath: taxid.to_string(),
+                taxpathsn: rank.to_string(),
+                percentage: 100.0,
+                cami_genome_id: None,
+                cami_otu: None,
+                hosts: None,
+            });
+        }
+
+        fill_up_to(
+            std::slice::from_mut(&mut sample),
+            Some("species"),
+            "genus",
+            &taxonomy,
+        );
+
+        assert!(
+            sample
+                .entries
+                .iter()
+                .any(|entry| entry.rank == "superkingdom")
+        );
+        assert!(sample.entries.iter().any(|entry| entry.rank == "strain"));
+        assert!(sample.entries.iter().any(|entry| entry.rank == "genus"));
+        fs::remove_dir_all(dir).unwrap();
     }
 }


### PR DESCRIPTION
### Motivation

- Improve data integrity by making the CAMI parser strict about malformed rows and invalid abundances and by surfacing contextual errors with line numbers.
- Ensure metric calculations and rank filtering behave deterministically by canonicalizing rank names and aggregating duplicate taxids consistently.
- Fix fill/fill-up and convert behaviors to preserve entries outside requested intervals and to normalize only successfully mapped rows.
- Document review findings and add coverage for corrected behaviors through unit tests. 

### Description

- Add `CODE_REVIEW.md` summarizing correctness fixes, follow-ups, and assessments across commands and shared modules. 
- Strengthen CAMI parsing in `src/cami.rs` to report line-numbered errors for truncated rows, rows before `@SampleID`, and non-finite/negative percentages, and add unit tests for these cases. 
- Preserve `@TaxonomyID` in `preview` output in `src/commands/preview.rs`. 
- In `src/commands/convert.rs` validate abundances (non-finite/negative rejected), drop unmappable rows from normalization, require at least one mapped row, and normalize after filtering mapped rows; also add fixture-backed tests exercising mixed-rank mapping and normalization. 
- In `src/commands/benchmark.rs` canonicalize entry ranks before applying rank filters and aggregate duplicate taxids when building ground-truth and prediction maps; add tests for duplicate aggregation and canonical rank alias matching. 
- In `src/processing.rs` make `fill_up_to` preserve entries outside the requested rank interval and add a test ensuring entries outside the interval remain. 
- Add and extend unit tests across modules (`cami`, `convert`, `benchmark`, `processing`) covering the introduced validations and behavior fixes. 

### Testing

- Ran the test suite with the added unit tests under `src/cami.rs`, `src/commands/convert.rs`, `src/commands/benchmark.rs`, and `src/processing.rs` using `cargo test`. 
- All automated unit tests, including the new fixture-backed and parser/metric/fillup tests, completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67c833b5a4832a837523432aa6e09f)